### PR TITLE
Added root Makefile with compiler and build options

### DIFF
--- a/func_sim/Makefile
+++ b/func_sim/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Building the single-cycle MIPS simulator
 # @author Pavel Kryukov <pavel.kryukov@phystech.com>
 # Copyright 2015 MIPT-MIPS iLab Project
@@ -13,27 +13,21 @@ include $(TRUNK)/options.mk
 #
 # Enter for building func_memory standalone program
 #
-func_sim: func_memory.o elf_parser.o func_instr.o func_sim.o main.o
+OBJS= func_memory.o elf_parser.o func_instr.o func_sim.o main.o
+DEPS= $(OBJS:.o=.d)
+
+func_sim: $(OBJS)
 	@# don't forget to link ELF library using "-l elf"
 	$(CXX) -o $@ $^ -l elf
 	@echo "---------------------------------"
 	@echo "$@ is built SUCCESSFULLY"
 
-main.o: main.cpp func_sim.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+-include $(DEPS)
 
-func_sim.o: func_sim.cpp func_sim.h types.h func_instr.h func_memory.h rf.h
+%.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-
-func_instr.o: func_instr.cpp func_instr.h types.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-    
-func_memory.o: func_memory.cpp func_memory.h types.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-
-elf_parser.o: elf_parser.cpp elf_parser.h types.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+	$(CXX) $(CXXFLAGS) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
 
 clean:
-	@-rm *.o
+	@-rm *.o *.d
 	@-rm func_sim

--- a/func_sim/Makefile
+++ b/func_sim/Makefile
@@ -7,30 +7,11 @@
 # specifying relative path to the TRUNK
 TRUNK= ../
 
-# C++ compiler flags
-CXXFLAGS= -std=c++11
-
-# paths to look for headers
-vpath %.h $(TRUNK)/common
-vpath %.h $(TRUNK)/func_sim/
-vpath %.h $(TRUNK)/func_sim/elf_parser/
-vpath %.h $(TRUNK)/func_sim/func_instr/
-vpath %.h $(TRUNK)/func_sim/func_memory/
-vpath %.cpp $(TRUNK)/func_sim/
-vpath %.cpp $(TRUNK)/func_sim/elf_parser/
-vpath %.cpp $(TRUNK)/func_sim/func_instr/
-vpath %.cpp $(TRUNK)/func_sim/func_memory/
-
-# option for C++ compiler specifying directories 
-# to search for headers
-INCL= -I ./ -I $(TRUNK)/common/ -I $(TRUNK)/func_sim/elf_parser/ -I $(TRUNK)/func_sim/func_memory/ -I $(TRUNK)/func_sim/func_instr
-
-#options for static linking of boost Unit Test library
-INCL_GTEST= -I $(TRUNK)/libs/gtest-1.6.0/include
-GTEST_LIB= $(TRUNK)/libs/gtest-1.6.0/libgtest.a
+# Including options and compiler flags
+include $(TRUNK)/options.mk
 
 #
-# Enter for building func_memory stand alone program
+# Enter for building func_memory standalone program
 #
 func_sim: func_memory.o elf_parser.o func_instr.o func_sim.o main.o
 	@# don't forget to link ELF library using "-l elf"

--- a/func_sim/elf_parser/Makefile
+++ b/func_sim/elf_parser/Makefile
@@ -9,21 +9,8 @@
 # specifying relative path to the TRUNK
 TRUNK= ../..
 
-# C++ compiler flags
-CXXFLAGS= -std=c++11
-
-# pathes to loop for headers
-vpath %.h $(TRUNK)/common
-
-# option for C++ compiler specifying directories 
-# to search for headers
-INCL= -I ./ -I $(TRUNK)common/
-
-# googletest directories
-GTEST_DIR= $(TRUNK)/libs/googletest
-GTEST_INCL= -I $(GTEST_DIR)/lib/include
-GTEST_LIB= $(GTEST_DIR)/lib/libgtest.a
-
+# Including options and compiler flags
+include $(TRUNK)/options.mk
 
 #
 # Enter for building elf_parser stand alone program

--- a/func_sim/elf_parser/Makefile
+++ b/func_sim/elf_parser/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Building the elf_parser for MIPS ElF binaries
 # @author Alexander Titov <alexander.igorevich.titov@gmail.com>
 # Copyright 2012 uArchSim iLab Project
@@ -15,17 +15,20 @@ include $(TRUNK)/options.mk
 #
 # Enter for building elf_parser stand alone program
 #
-elf_parser: elf_parser.o main.o
+OBJS= elf_parser.o main.o
+DEPS= $(OBJS:.o=.d)
+
+elf_parser: $(OBJS)
 	@# don't forget to link ELF library using "-l elf"
-	$(CXX) $(CXXFLAGS) $^ -o $@ -l elf
+	$(CXX) -o $@ $^ -l elf
 	@echo "---------------------------------"
 	@echo "$@ is built SUCCESSFULLY"
 
-elf_parser.o: elf_parser.cpp elf_parser.h types.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+-include $(DEPS)
 
-main.o: main.cpp elf_parser.o
+%.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+	$(CXX) $(CXXFLAGS) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
 
 #
 # Enter for building elf_parser unit test
@@ -36,19 +39,27 @@ test: unit_test
 	@./$<
 	@echo "Unit testing for the moduler ELF parser passed SUCCESSFULLY!"
 
-unit_test: unit_test.o elf_parser.o $(GTEST_LIB)
+OBJS= unit_test.o elf_parser.o
+DEPS= $(OBJS:.o=.d)
+
+unit_test: $(OBJS) $(GTEST_LIB)
 	@# don't forget to link ELF library using "-l elf"
 	@# and use "-lpthread" options for Google Test
 	$(CXX) $(GTEST_INCL) -pthread -lpthread $^ -o $@ -l elf
 	@echo "---------------------------------"
 	@echo "$@ is built SUCCESSFULLY"
 
-unit_test.o: unit_test.cpp elf_parser.o $(GTEST_LIB)
-	$(CXX) $(CXXFLAGS) $(GTEST_INCL) $(INCL) -c $< $(GTEST_LIB)
+
+-include $(DEPS)
+
+unit_test.o: unit_test.cpp $(GTEST_LIB)
+	$(CXX) $(CXXFLAGS) $(GTEST_INCL) -c $< $(INCL)
+	$(CXX) $(CXXFLAGS) $(GTEST_INCL) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
 
 $(GTEST_LIB):
 	$(MAKE) -C $(GTEST_DIR)
 
+
 clean:
-	@-rm *.o
+	@-rm -rf *.o *.d
 	@-rm -rf elf_parser unit_test

--- a/func_sim/func_instr/Makefile
+++ b/func_sim/func_instr/Makefile
@@ -10,25 +10,24 @@ TRUNK= ../..
 # Including options and compiler flags
 include $(TRUNK)/options.mk
 
+#
 # Enter for building func_memory standalone program
 #
-disasm: func_memory.o elf_parser.o disasm.o func_instr.o
+OBJS= func_memory.o elf_parser.o disasm.o func_instr.o
+DEPS= $(OBJS:.o=.d)
+
+disasm: $(OBJS)
 	@# don't forget to link ELF library using "-l elf"
-	$(CXX) $(CXXFLAGS) -o $@ $^ -l elf
+	$(CXX) -o $@ $^ -l elf
 	@echo "---------------------------------"
 	@echo "$@ is built SUCCESSFULLY"
 
-func_instr.o: func_instr.cpp func_instr.h types.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-    
-func_memory.o: func_memory.cpp func_memory.h types.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+-include $(DEPS)
 
-elf_parser.o: elf_parser.cpp elf_parser.h types.h
+%.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+	$(CXX) $(CXXFLAGS) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
 
-disasm.o: disasm.cpp func_memory.h types.h func_instr.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
 
 #
 # Enter for building func_memory unit test
@@ -39,19 +38,28 @@ test: unit_test
 	@./$<
 	@echo "Unit testing for the moduler functional memory passed SUCCESSFULLY!"
 
-unit_test: unit_test.o func_memory.o elf_parser.o func_instr.o $(GTEST_LIB)
+OBJS= unit_test.o func_memory.o elf_parser.o func_instr.o 
+DEPS= $(OBJS:.o=.d)
+
+unit_test: $(OBJS) $(GTEST_LIB)
 	@# don't forget to link ELF library using "-l elf"
 	@# and use "-lpthread" options for Google Test
 	$(CXX) $(GTEST_INCL) -pthread -lpthread $^ -o $@ -l elf
 	@echo "---------------------------------"
 	@echo "$@ is built SUCCESSFULLY"
 
-unit_test.o: unit_test.cpp func_instr.h $(GTEST_LIB)
-	$(CXX) $(CXXFLAGS) $(GTEST_INCL) $(INCL) -c $<
+
+-include $(DEPS)
+
+unit_test.o: unit_test.cpp $(GTEST_LIB)
+	$(CXX) $(CXXFLAGS) $(GTEST_INCL) -c $< $(INCL)
+	$(CXX) $(CXXFLAGS) $(GTEST_INCL) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
 
 $(GTEST_LIB):
 	$(MAKE) -C $(GTEST_DIR)
 
+
 clean:
-	@-rm *.o
+	@-rm -rf *.o *.d
 	@-rm -rf disasm unit_test
+

--- a/func_sim/func_instr/Makefile
+++ b/func_sim/func_instr/Makefile
@@ -36,7 +36,7 @@ test: unit_test
 	@echo ""
 	@echo "Running ./$<\n"
 	@./$<
-	@echo "Unit testing for the moduler functional memory passed SUCCESSFULLY!"
+	@echo "Unit testing for the moduler functional instructions passed SUCCESSFULLY!"
 
 OBJS= unit_test.o func_memory.o elf_parser.o func_instr.o
 DEPS= $(OBJS:.o=.d)

--- a/func_sim/func_instr/Makefile
+++ b/func_sim/func_instr/Makefile
@@ -10,27 +10,11 @@ TRUNK= ../..
 # C++ compiler flags
 CXXFLAGS= -std=c++11
 
-# paths to look for headers
-vpath %.h $(TRUNK)/common
-vpath %.h $(TRUNK)/func_sim/elf_parser/
-vpath %.h $(TRUNK)/func_sim/func_instr/
-vpath %.h $(TRUNK)/func_sim/func_memory/
-vpath %.cpp $(TRUNK)/func_sim/elf_parser/
-vpath %.cpp $(TRUNK)/func_sim/func_instr/
-vpath %.cpp $(TRUNK)/func_sim/func_memory/
 
-# option for C++ compiler specifying directories 
-# to search for headers
-INCL= -I ./ -I $(TRUNK)/common/ -I $(TRUNK)/func_sim/elf_parser/ -I $(TRUNK)/func_sim/func_memory/ 
+# Including options and compiler flags
+include $(TRUNK)/options.mk
 
-
-# googletest directories
-GTEST_DIR= $(TRUNK)/libs/googletest
-GTEST_INCL= -I $(GTEST_DIR)/lib/include
-GTEST_LIB= $(GTEST_DIR)/lib/libgtest.a
-
-#
-# Enter for building func_memory stand alone program
+# Enter for building func_memory standalone program
 #
 disasm: func_memory.o elf_parser.o disasm.o func_instr.o
 	@# don't forget to link ELF library using "-l elf"

--- a/func_sim/func_instr/Makefile
+++ b/func_sim/func_instr/Makefile
@@ -7,10 +7,6 @@
 # specifying relative path to the TRUNK
 TRUNK= ../..
 
-# C++ compiler flags
-CXXFLAGS= -std=c++11
-
-
 # Including options and compiler flags
 include $(TRUNK)/options.mk
 

--- a/func_sim/func_instr/Makefile
+++ b/func_sim/func_instr/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Building the disasm for MIPS binaries
 # @author Pavel Kryukov <pavel.kryukov@phystech.com>
 # Copyright 2014 MIPT-MIPS iLab Project
@@ -11,7 +11,7 @@ TRUNK= ../..
 include $(TRUNK)/options.mk
 
 #
-# Enter for building func_memory standalone program
+# Enter for building func_instr standalone program
 #
 OBJS= func_memory.o elf_parser.o disasm.o func_instr.o
 DEPS= $(OBJS:.o=.d)
@@ -30,7 +30,7 @@ disasm: $(OBJS)
 
 
 #
-# Enter for building func_memory unit test
+# Enter for building func_instr unit test
 #
 test: unit_test
 	@echo ""
@@ -38,7 +38,7 @@ test: unit_test
 	@./$<
 	@echo "Unit testing for the moduler functional memory passed SUCCESSFULLY!"
 
-OBJS= unit_test.o func_memory.o elf_parser.o func_instr.o 
+OBJS= unit_test.o func_memory.o elf_parser.o func_instr.o
 DEPS= $(OBJS:.o=.d)
 
 unit_test: $(OBJS) $(GTEST_LIB)
@@ -62,4 +62,3 @@ $(GTEST_LIB):
 clean:
 	@-rm -rf *.o *.d
 	@-rm -rf disasm unit_test
-

--- a/func_sim/func_memory/Makefile
+++ b/func_sim/func_memory/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Building the elf_parser for MIPS ElF binaries
 # @author Alexander Titov <alexander.igorevich.titov@gmail.com>
 # Copyright 2012 uArchSim iLab Project
@@ -13,20 +13,22 @@ include $(TRUNK)/options.mk
 #
 # Enter for building func_memory standalone program
 #
-func_memory: func_memory.o elf_parser.o main.o
+OBJS= func_memory.o elf_parser.o main.o
+
+DEPS= $(OBJS:.o=.d)
+
+func_instr: $(OBJS)
 	@# don't forget to link ELF library using "-l elf"
 	$(CXX) -o $@ $^ -l elf
 	@echo "---------------------------------"
 	@echo "$@ is built SUCCESSFULLY"
 
-func_memory.o: func_memory.cpp func_memory.h types.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+-include $(DEPS)
 
-elf_parser.o: elf_parser.cpp elf_parser.h types.h
+%.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+	$(CXX) $(CXXFLAGS) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
 
-main.o: main.cpp func_memory.h types.h
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
 
 #
 # Enter for building func_memory unit test
@@ -37,19 +39,26 @@ test: unit_test
 	@./$<
 	@echo "Unit testing for the moduler functional memory passed SUCCESSFULLY!"
 
-unit_test: unit_test.o func_memory.o elf_parser.o $(GTEST_LIB)
+OBJS= unit_test.o func_memory.o elf_parser.o
+DEPS= $(OBJS:.o=.d)
+
+unit_test: $(OBJS) $(GTEST_LIB)
 	@# don't forget to link ELF library using "-l elf"
 	@# and use "-lpthread" options for Google Test
 	$(CXX) $(GTEST_INCL) -pthread -lpthread $^ -o $@ -l elf
 	@echo "---------------------------------"
 	@echo "$@ is built SUCCESSFULLY"
 
-unit_test.o: unit_test.cpp func_memory.o elf_parser.o $(GTEST_LIB)
-	$(CXX) $(CXXFLAGS) $(GTEST_INCL) $(INCL) -c $<
+
+-include $(DEPS)
+
+unit_test.o: unit_test.cpp $(GTEST_LIB)
+	$(CXX) $(CXXFLAGS) $(GTEST_INCL) -c $< $(INCL)
+	$(CXX) $(CXXFLAGS) $(GTEST_INCL) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
 
 $(GTEST_LIB):
 	$(MAKE) -C $(GTEST_DIR)
 
 clean:
-	@-rm *.o
+	@-rm -rf *.o *.d
 	@-rm -rf func_memory unit_test

--- a/func_sim/func_memory/Makefile
+++ b/func_sim/func_memory/Makefile
@@ -7,25 +7,11 @@
 # specifying relative path to the TRUNK
 TRUNK= ../..
 
-# C++ compiler flags
-CXXFLAGS= -std=c++11
-
-# paths to look for headers
-vpath %.h $(TRUNK)/common
-vpath %.h $(TRUNK)/func_sim/elf_parser/
-vpath %.cpp $(TRUNK)/func_sim/elf_parser/
-
-# option for C++ compiler specifying directories 
-# to search for headers
-INCL= -I ./ -I $(TRUNK)/common/ -I $(TRUNK)/func_sim/elf_parser/
-
-# googletest directories
-GTEST_DIR= $(TRUNK)/libs/googletest
-GTEST_INCL= -I $(GTEST_DIR)/lib/include
-GTEST_LIB= $(GTEST_DIR)/lib/libgtest.a
+# Including options and compiler flags
+include $(TRUNK)/options.mk
 
 #
-# Enter for building func_memory stand alone program
+# Enter for building func_memory standalone program
 #
 func_memory: func_memory.o elf_parser.o main.o
 	@# don't forget to link ELF library using "-l elf"

--- a/options.mk
+++ b/options.mk
@@ -1,0 +1,22 @@
+# C++ compiler flags
+CXXFLAGS= -std=c++11
+
+# Paths to look for headers
+vpath %.h $(TRUNK)/common
+vpath %.h $(TRUNK)/func_sim/
+vpath %.h $(TRUNK)/func_sim/elf_parser/
+vpath %.h $(TRUNK)/func_sim/func_instr/
+vpath %.h $(TRUNK)/func_sim/func_memory/
+vpath %.cpp $(TRUNK)/func_sim/
+vpath %.cpp $(TRUNK)/func_sim/elf_parser/
+vpath %.cpp $(TRUNK)/func_sim/func_instr/
+vpath %.cpp $(TRUNK)/func_sim/func_memory/
+
+# GoogleTest directories
+GTEST_DIR= $(TRUNK)/libs/googletest
+GTEST_INCL= -I $(GTEST_DIR)/lib/include
+GTEST_LIB= $(GTEST_DIR)/lib/libgtest.a
+
+# option for C++ compiler specifying directories 
+# to search for headers
+INCL= -I ./ -I $(TRUNK)/common/ -I $(TRUNK)/func_sim/elf_parser/ -I $(TRUNK)/func_sim/func_memory/ -I $(TRUNK)/func_sim/func_instr

--- a/perf_sim/Makefile
+++ b/perf_sim/Makefile
@@ -15,26 +15,25 @@ include $(TRUNK)/options.mk
 #
 # Enter for build "perf_sim" program
 #
-perf_sim: elf_parser.o func_memory.o func_instr.o perf_sim.o main.o
-	$(CXX) $(CXXFLAGS) -o $@ $^ -l elf
-	@echo "--------------------------------"
-	@echo "$@ is built successfully."
-elf_parser.o: elf_parser.cpp
+OBJS= elf_parser.o func_memory.o func_instr.o perf_sim.o main.o
+DEPS= $(OBJS:.o=.d)
+
+perf_sim: $(OBJS)
+	@# don't forget to link ELF library using "-l elf"
+	$(CXX) -o $@ $^ -l elf
+	@echo "---------------------------------"
+	@echo "$@ is built SUCCESSFULLY"
+
+-include $(DEPS)
+
+%.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-func_memory.o: func_memory.cpp
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-func_instr.o: func_instr.cpp
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-#log.o: log.cpp
-#	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-perf_sim.o: perf_sim.cpp
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
-main.o: main.cpp
-	$(CXX) $(CXXFLAGS) -c $< $(INCL)
+	$(CXX) $(CXXFLAGS) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
+
 
 #
 # Enter to remove all created files
 #
 clean:
-	@-rm *.o
+	@-rm -rf *.o *.d
 	@-rm perf_sim

--- a/perf_sim/Makefile
+++ b/perf_sim/Makefile
@@ -5,29 +5,15 @@
 # Ladin Oleg.
 #
 
-# C++ compiler flags
-CXXFLAGS= -std=c++11
 
-# Specifying relative path to the trunk.
+# Specifying relative path to the trunk
 TRUNK= ..
 
-# Paths to look for files.
-vpath %.h $(TRUNK)/common/
-vpath %.h $(TRUNK)/perf_sim/
-vpath %.h $(TRUNK)/func_sim/elf_parser/
-vpath %.h $(TRUNK)/func_sim/func_instr/
-vpath %.h $(TRUNK)/func_sim/func_memory/
-vpath %.cpp $(TRUNK)/perf_sim/
-vpath %.cpp $(TRUNK)/func_sim/elf_parser/
-vpath %.cpp $(TRUNK)/func_sim/func_instr/
-vpath %.cpp $(TRUNK)/func_sim/func_memory/
-
-# Options for compiler specifying paths to look for headers.
-INCL= -I ./ -I $(TRUNK)/common/ -I $(TRUNK)/func_sim/elf_parser/ \
-  -I $(TRUNK)/func_sim/func_memory/  -I $(TRUNK)/func_sim/func_instr/
+# Including options and compiler flags
+include $(TRUNK)/options.mk
 
 #
-# Enter for build "perf_sim" programm.
+# Enter for build "perf_sim" program
 #
 perf_sim: elf_parser.o func_memory.o func_instr.o perf_sim.o main.o
 	$(CXX) $(CXXFLAGS) -o $@ $^ -l elf
@@ -47,7 +33,7 @@ main.o: main.cpp
 	$(CXX) $(CXXFLAGS) -c $< $(INCL)
 
 #
-# Enter to remove all created files.
+# Enter to remove all created files
 #
 clean:
 	@-rm *.o

--- a/perf_sim/mem/Makefile
+++ b/perf_sim/mem/Makefile
@@ -11,11 +11,8 @@ CXXFLAGS= -std=c++11
 # Specifying relative path to the trunk.
 TRUNK= ../..
 
-# Paths to look for files.
-vpath %.h $(TRUNK)/common/
-
-# Options for compiler specifuing paths to look for headers.
-INCL= -I ./ -I $(TRUNK)/common/
+# Including options and compiler flags
+include $(TRUNK)/options.mk
 
 #
 # Enter for build "miss_rate_sim" program.


### PR DESCRIPTION
I'm not sure whether it is OK to add all the paths into the root Makefile (many `vpath` and `INCL` dirs), as in case there are headers with same name, It will not work properly, and such an overhead might slow down the build a little.

But I believe for relatively small `mips-mips` it's quite acceptable for now, as the build takes few seconds and all the headers are named differently and everything just works.

This should accomplish #48