### PR TITLE
WIP: Added parsing paramaters with Boost for perf_sim

### DIFF
--- a/options.mk
+++ b/options.mk
@@ -20,5 +20,6 @@ GTEST_LIB= $(GTEST_DIR)/lib/libgtest.a
 
 # option for C++ compiler specifying directories 
 # to search for headers
-INCL= -I $(TRUNK)/ -I /usr/local/include/boost/
+INCL= -I $(TRUNK)/
+BOOST_INCL= -I /usr/local/include/boost/
 

--- a/options.mk
+++ b/options.mk
@@ -20,5 +20,5 @@ GTEST_LIB= $(GTEST_DIR)/lib/libgtest.a
 
 # option for C++ compiler specifying directories 
 # to search for headers
-INCL= -I $(TRUNK)/
+INCL= -I $(TRUNK)/ -I /usr/local/include/boost/
 

--- a/perf_sim/Makefile
+++ b/perf_sim/Makefile
@@ -26,11 +26,15 @@ perf_sim: $(OBJS)
 
 -include $(DEPS)
 
+config.o: config.cpp
+	@echo "[$(CXX)] $@"
+	@$(CXX) $(CXXFLAGS) -c $< $(INCL) $(BOOST_INCL)
+	@$(CXX) $(CXXFLAGS) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL) $(BOOST_INCL)
+
 %.o: %.cpp
 	@echo "[$(CXX)] $@"
 	@$(CXX) $(CXXFLAGS) -c $< $(INCL)
 	@$(CXX) $(CXXFLAGS) -MM -o $(patsubst %.o, %.d, $@) $< $(INCL)
-
 
 #
 # Enter to remove all created files

--- a/perf_sim/Makefile
+++ b/perf_sim/Makefile
@@ -15,12 +15,12 @@ include $(TRUNK)/options.mk
 #
 # Enter for build "perf_sim" program
 #
-OBJS= elf_parser.o func_memory.o func_instr.o perf_sim.o main.o
+OBJS= elf_parser.o func_memory.o func_instr.o perf_sim.o config.o main.o
 DEPS= $(OBJS:.o=.d)
 
 perf_sim: $(OBJS)
 	@# don't forget to link ELF library using "-l elf"
-	$(CXX) -o $@ $^ -l elf
+	$(CXX) -o $@ $^ -l elf -lboost_program_options
 	@echo "---------------------------------"
 	@echo "$@ is built SUCCESSFULLY"
 

--- a/perf_sim/config.cpp
+++ b/perf_sim/config.cpp
@@ -1,6 +1,5 @@
 /*
  * config.cpp - implementation of Config class
- * @author Pavel Kryukov pavel.kryukov@phystech.edu
  * Copyright 2017 MIPT-MIPS
  */
 
@@ -13,13 +12,8 @@
 /* boost - program option parsing */
 #include <boost/program_options.hpp>
 
-using namespace std;
-
 /* constructor and destructor */
-Config::Config() :
-    /* by default, there is no limit of simulation and silent mode is on */
-    num_steps( -1),
-    disassembly_on( false)
+Config::Config()
 {
 
 }
@@ -38,18 +32,18 @@ int Config::handleArgs( int argc, char** argv)
     po::options_description description( "Allowed options");
 
     description.add_options()
-        ( "binary,b",      po::value<string> ( &this->binary_filename),
-                                                            "Input binary file")
+        ( "binary,b",      po::value<std::string>( &this->binary_filename)->required(),
+          "input binary file")
 
-        ( "numsteps,n",    po::value<int>    ( &this->num_steps),
-                               "Number of instructions to run. Defaults to -1,"
-                               " which means there is no limit for simulation.")
+        ( "numsteps,n",    po::value<int>( &this->num_steps)->required(),
+          "number of instructions to run")
 
-        ( "disassembly,d", po::bool_switch   ( &this->disassembly_on),
-                                                            "Print disassembly")
+        /* by default, the silent mode is on */
+        ( "disassembly,d", po::bool_switch( &this->disassembly_on)->default_value( false),
+          "print disassembly")
 
         ( "help,h",
-                                                      "Print this help message");
+          "print this help message");
 
     po::positional_options_description posDescription;
     posDescription.add( "binary", 1).add( "numsteps", 2);
@@ -62,43 +56,29 @@ int Config::handleArgs( int argc, char** argv)
                                     positional(posDescription).
                                     run(),
                                     vm);
+
+
+        /* parsing help */
+        if ( vm.count( "help"))
+        {
+            std::cout << "Functional and performance simulators for MIPS-based CPU.";
+            std::cout << std::endl << std::endl;
+            std::cout << description << std::endl;
+            std::exit( EXIT_SUCCESS);
+        }
+
+        /* calling notify AFTER parsing help, as otherwise
+         * absent required args will cause errors
+         */
         po::notify(vm);
     }
     catch ( const std::exception& e)
     {
-        (void)e;
-        cout << description << endl;
-        exit(0);
-    }
-
-    /* parsing help */
-    if ( vm.count( "help"))
-    {
-         cout << "Functional and performance simulators for MIPS-based CPU.";
-         cout << endl << endl;
-         cout << description << endl;
-         exit(0);
+        std::cout << argv[0] << ": " << e.what();
+        std::cout << std::endl << std::endl;
+        std::cout << description << std::endl;
+        std::exit( EXIT_SUCCESS);
     }
 
     return 0;
 }
-
-
-/* get methods */
-string Config::binaryFilename() const
-{
-    return this->binary_filename;
-}
-
-
-int Config::numSteps() const
-{
-    return this->num_steps;
-}
-
-
-bool Config::disassemblyOn() const
-{
-    return this->disassembly_on;
-}
-

--- a/perf_sim/config.cpp
+++ b/perf_sim/config.cpp
@@ -1,0 +1,104 @@
+/*
+ * config.cpp - implementation of Config class
+ * @author Pavel Kryukov pavel.kryukov@phystech.edu
+ * Copyright 2017 MIPT-MIPS
+ */
+
+/* Simulator modules */
+#include "config.h"
+
+/* Generic C++ */
+#include <iostream>
+
+/* boost - program option parsing */
+#include <boost/program_options.hpp>
+
+using namespace std;
+
+/* constructor and destructor */
+Config::Config() :
+    /* by default, there is no limit of simulation and silent mode is on */
+    num_steps( -1),
+    disassembly_on( false)
+{
+
+}
+
+Config::~Config()
+{
+
+}
+
+
+/* basic method */
+int Config::handleArgs( int argc, char** argv)
+{
+    namespace po = boost::program_options;
+
+    po::options_description description( "Allowed options");
+
+    description.add_options()
+        ( "binary,b",      po::value<string> ( &this->binary_filename),
+                                                            "Input binary file")
+
+        ( "numsteps,n",    po::value<int>    ( &this->num_steps),
+                               "Number of instructions to run. Defaults to -1,"
+                               " which means there is no limit for simulation.")
+
+        ( "disassembly,d", po::bool_switch   ( &this->disassembly_on),
+                                                            "Print disassembly")
+
+        ( "help,h",
+                                                      "Print this help message");
+
+    po::positional_options_description posDescription;
+    posDescription.add( "binary", 1).add( "numsteps", 2);
+    po::variables_map vm;
+
+    try
+    {
+        po::store(po::command_line_parser(argc, argv).
+                                    options(description).
+                                    positional(posDescription).
+                                    run(),
+                                    vm);
+        po::notify(vm);
+    }
+    catch ( const std::exception& e)
+    {
+        (void)e;
+        cout << description << endl;
+        exit(0);
+    }
+
+    /* parsing help */
+    if ( vm.count( "help"))
+    {
+         cout << "Functional and performance simulators for MIPS-based CPU.";
+         cout << endl << endl;
+         cout << description << endl;
+         exit(0);
+    }
+
+    return 0;
+}
+
+
+/* get methods */
+string Config::binaryFilename() const
+{
+    return this->binary_filename;
+}
+
+
+int Config::numSteps() const
+{
+    return this->num_steps;
+}
+
+
+bool Config::disassemblyOn() const
+{
+    return this->disassembly_on;
+}
+

--- a/perf_sim/config.h
+++ b/perf_sim/config.h
@@ -1,6 +1,5 @@
 /*
  * config.h - class for analysing and handling of inputed arguments
- * @author Pavel Kryukov pavel.kryukov@phystech.edu
  * Copyright 2017 MIPT-MIPS
  */
 
@@ -8,29 +7,21 @@
 #define CONFIG_H
 
 #include <string>
-using namespace std;
 
 class Config
 {
-private:
-    /* variables */
-    string binary_filename;
-    int    num_steps;
-    bool   disassembly_on;
-
 public:
+    /* variables */
+    std::string binary_filename;
+    int         num_steps;
+    bool        disassembly_on;
+
     /* constructors */
     Config();
     ~Config();
 
     /* methods */
     int handleArgs( int argc, char** argv);
-
-    /* get methods */
-    string binaryFilename() const;
-    int    numSteps()       const;
-    bool   disassemblyOn()  const;
-
 };
 
 #endif  // CONFIG_H

--- a/perf_sim/config.h
+++ b/perf_sim/config.h
@@ -1,0 +1,36 @@
+/*
+ * config.h - class for analysing and handling of inputed arguments
+ * @author Pavel Kryukov pavel.kryukov@phystech.edu
+ * Copyright 2017 MIPT-MIPS
+ */
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <string>
+using namespace std;
+
+class Config
+{
+private:
+    /* variables */
+    string binary_filename;
+    int    num_steps;
+    bool   disassembly_on;
+
+public:
+    /* constructors */
+    Config();
+    ~Config();
+
+    /* methods */
+    int handleArgs( int argc, char** argv);
+
+    /* get methods */
+    string binaryFilename() const;
+    int    numSteps()       const;
+    bool   disassemblyOn()  const;
+
+};
+
+#endif  // CONFIG_H

--- a/perf_sim/main.cpp
+++ b/perf_sim/main.cpp
@@ -14,34 +14,16 @@
 
 /* Simulator modules. */
 #include "perf_sim.h"
+#include "config.h"
 
-int main( int argc, char* argv[])
+int main( int argc, char** argv)
 {
-    bool is_silent = true; // by default it's silent mode
-    switch( argc)
-    {
-        case 3: // check arguments (silent mode)
-            if ( ( argv[ 1] == nullptr) || ( atoi( argv[ 2]) < 0))
-            {
-                std::cerr << "ERROR: Wrong arguments!\n";
-                std::exit( EXIT_FAILURE);
-            }
-            break;
-        case 4: // check arguments (normal mode)
-            if ( ( argv[ 1] == nullptr) || ( atoi( argv[ 2]) < 0) ||
-                 ( strcmp( argv[ 3], "-d")))
-            {
-                std::cerr << "ERROR: Wrong arguments!\n";
-                std::exit( EXIT_FAILURE);
-            }
-            is_silent = false; // disable silent mode
-            break;
-        default: // wrong number of arguments
-            std::cerr << "ERROR: Wrong number of arguments!\n";
-            std::exit( EXIT_FAILURE);
-    }
+    /* Analysing and handling of inserted arguments */
+    Config handler;
+    handler.handleArgs( argc, argv);
 
-    PerfMIPS p_mips( !is_silent);
-    p_mips.run( argv[ 1], atoi( argv[ 2]));
+    /* running simulation */
+    PerfMIPS p_mips( handler.disassemblyOn());
+    p_mips.run( handler.binaryFilename(), handler.numSteps());
     return 0;
 }

--- a/perf_sim/main.cpp
+++ b/perf_sim/main.cpp
@@ -23,7 +23,7 @@ int main( int argc, char** argv)
     handler.handleArgs( argc, argv);
 
     /* running simulation */
-    PerfMIPS p_mips( handler.disassemblyOn());
-    p_mips.run( handler.binaryFilename(), handler.numSteps());
+    PerfMIPS p_mips( handler.disassembly_on);
+    p_mips.run( handler.binary_filename, handler.num_steps);
     return 0;
 }

--- a/perf_sim/perf_sim.cpp
+++ b/perf_sim/perf_sim.cpp
@@ -102,14 +102,15 @@ PerfMIPS::~PerfMIPS()
     delete wp_writeback_2_memory_stall;
 }
 
-void PerfMIPS::run( const std::string& tr, int instrs_to_run)
+void PerfMIPS::run( const std::string& tr, const int instrs_to_run)
 {
     mem = new FuncMemory( tr.c_str()); // create functional memory
     PC = mem->startPC(); // get starting programm address
     PC_is_valid = true; // now PC is valid
     executed_instrs = 0;
     int cycle = 0;
-    while ( executed_instrs < instrs_to_run) // main loop
+
+    while ( instrs_to_run == -1 || executed_instrs < instrs_to_run) // main loop
     {
         clockFetch( cycle);
         clockDecode( cycle);

--- a/perf_sim/perf_sim.cpp
+++ b/perf_sim/perf_sim.cpp
@@ -102,15 +102,14 @@ PerfMIPS::~PerfMIPS()
     delete wp_writeback_2_memory_stall;
 }
 
-void PerfMIPS::run( const std::string& tr, const int instrs_to_run)
+void PerfMIPS::run( const std::string& tr, int instrs_to_run)
 {
     mem = new FuncMemory( tr.c_str()); // create functional memory
     PC = mem->startPC(); // get starting programm address
     PC_is_valid = true; // now PC is valid
     executed_instrs = 0;
     int cycle = 0;
-
-    while ( instrs_to_run == -1 || executed_instrs < instrs_to_run) // main loop
+    while ( executed_instrs < instrs_to_run) // main loop
     {
         clockFetch( cycle);
         clockDecode( cycle);


### PR DESCRIPTION
I have started working on #26.
@pavelkryukov, I have just mostly used the same patterns as those in your code from MDSP, with minor changes.

I would be grateful for a brief review of what has been done so that I could proceed and remove `func_sim` entry point.

I have just few questions:
1. From the code it's not very clear what are the naming conventions, so I tried to observe the rules expounded in our wiki. Sorry if I get it wrong somewhere.
2. The above-mentioned wiki emphasises that we shouldn't use C++ exceptions. I'm wondering how it is possible to handle `boost` errors without catching the exceptions thrown.
3. Should I create similar handlers for compiling modules like `elf_parser` as standalone modules?
4. Removing the `func_sim` entry point implies restructuring the directory tree. Which way should it be  reorganised in? 

Something like
```
sim/     ->  perf_sim/ -> ...
         | 
         ->  func_sim/ -> ...
         |
         ->  main.cpp
```

and called like
```./sim ../tests/samples/factorial.out --mode=perf```
?