### PR TITLE
Fixed jal not saving PC to ra register

### DIFF
--- a/func_sim/func_instr/func_instr.cpp
+++ b/func_sim/func_instr/func_instr.cpp
@@ -17,82 +17,82 @@ const FuncInstr::ISAEntry FuncInstr::isaTable[] =
 {
     { "###",    0xFF,  FORMAT_UNKNOWN, OUT_R_ARITHM,  0, &FuncInstr::execute_unknown},
 
-    // name    funct    format    operation   memsize           pointer
-    { "add",    0x20,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_add},
-    { "addu",   0x21,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_addu},
-    { "sub",    0x22,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_sub},
-    { "subu",   0x23,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_subu},
-    { "addi",   0x8,   FORMAT_I, OUT_I_ARITHM,  0, &FuncInstr::execute_addi},
-    { "addiu",  0x9,   FORMAT_I, OUT_I_ARITHM,  0, &FuncInstr::execute_addiu},
+    // name    funct    format    operation     memsize           pointer
+    { "add",    0x20,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_add},
+    { "addu",   0x21,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_addu},
+    { "sub",    0x22,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_sub},
+    { "subu",   0x23,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_subu},
+    { "addi",   0x8,   FORMAT_I, OUT_I_ARITHM,     0, &FuncInstr::execute_addi},
+    { "addiu",  0x9,   FORMAT_I, OUT_I_ARITHM,     0, &FuncInstr::execute_addiu},
 
-    // name    funct    format    operation   memsize           pointer
-    { "mult",   0x18,  FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_mult}, 
-    { "multu",  0x19,  FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_multu},
+    // name    funct    format    operation     memsize           pointer
+    { "mult",   0x18,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_mult},
+    { "multu",  0x19,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_multu},
 
-    // name    funct    format    operation   memsize           pointer
-    { "div",    0x1A,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_div},
-    { "divu",   0x1B,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_divu},
+    // name    funct    format    operation     memsize           pointer
+    { "div",    0x1A,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_div},
+    { "divu",   0x1B,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_divu},
 
-    // name    funct    format    operation   memsize           pointer
-    { "mfhi",   0x10,  FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_mfhi},
-    { "mflo",   0x12,  FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_mflo},
-    { "mthi",   0x11,  FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_mthi},
-    { "mtlo",   0x13,  FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_mtlo},
-    
-    // name    funct    format    operation   memsize           pointer
-    { "sll",    0x0,   FORMAT_R, OUT_R_SHAMT,   0, &FuncInstr::execute_sll},
-    { "srl",    0x2,   FORMAT_R, OUT_R_SHAMT,   0, &FuncInstr::execute_srl},
-    { "sra",    0x3,   FORMAT_R, OUT_R_SHAMT,	0, &FuncInstr::execute_sra},
-    { "sllv",   0x4,   FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_sllv},
-    { "srlv",   0x6,   FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_srlv},
-    { "srav",   0x7,   FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_srav},
-    { "lui",    0xF,   FORMAT_I, OUT_I_CONST,   0, &FuncInstr::execute_lui},
-    { "slt",    0x2A,  FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_slt},
-    { "sltu",   0x2B,  FORMAT_R, OUT_R_ARITHM,	0, &FuncInstr::execute_sltu},
-    { "slti",   0xA,   FORMAT_I, OUT_I_ARITHM,	0, &FuncInstr::execute_slti},
-    { "sltiu",  0xB,   FORMAT_I, OUT_I_ARITHM,	0, &FuncInstr::execute_sltiu},
+    // name    funct    format    operation     memsize           pointer
+    { "mfhi",   0x10,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_mfhi},
+    { "mflo",   0x12,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_mflo},
+    { "mthi",   0x11,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_mthi},
+    { "mtlo",   0x13,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_mtlo},
 
-    // name    funct    format    operation   memsize           pointer
-    { "and",    0x24,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_and},
-    { "or",     0x25,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_or},
-    { "xor",    0x26,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_xor},
-    { "nor",    0x27,  FORMAT_R, OUT_R_ARITHM,  0, &FuncInstr::execute_nor},
-    
-    // name    funct    format    operation   memsize           pointer
-    { "andi",   0xC,   FORMAT_I, OUT_I_ARITHM,  0, &FuncInstr::execute_andi},
-    { "ori",    0xD,   FORMAT_I, OUT_I_ARITHM,  0, &FuncInstr::execute_ori},
-    { "xori",   0xE,   FORMAT_I, OUT_I_ARITHM,  0, &FuncInstr::execute_xori},
-    
-    // name    funct    format    operation   memsize           pointer
-    { "beq",    0x4,   FORMAT_I, OUT_I_BRANCH,  0, &FuncInstr::execute_beq},
-    { "bne",    0x5,   FORMAT_I, OUT_I_BRANCH,  0, &FuncInstr::execute_bne},
-    { "blez",   0x6,   FORMAT_I, OUT_I_BRANCH,  0, &FuncInstr::execute_blez},
-    { "bgtz",   0x7,   FORMAT_I, OUT_I_BRANCH,  0, &FuncInstr::execute_bgtz},
-    { "jal",    0x3,   FORMAT_J, OUT_J_JUMP,    0, &FuncInstr::execute_jal},
-    { "j",      0x2,   FORMAT_J, OUT_J_JUMP,    0, &FuncInstr::execute_j},
-    { "jr",     0x8,   FORMAT_R, OUT_R_JUMP,    0, &FuncInstr::execute_jr},
-    { "jalr",   0x9,   FORMAT_R, OUT_R_JUMP,    0, &FuncInstr::execute_jalr},
-    
-    // name    funct    format    operation   memsize           pointer
-    { "lb",     0x20,  FORMAT_I, OUT_I_LOAD,    1, &FuncInstr::calculate_load_addr},
-    { "lbu",    0x24,  FORMAT_I, OUT_I_LOADU,   1, &FuncInstr::calculate_load_addr},
-    { "lh",     0x21,  FORMAT_I, OUT_I_LOAD,    2, &FuncInstr::calculate_load_addr},
-    { "lhu",    0x25,  FORMAT_I, OUT_I_LOADU,   2, &FuncInstr::calculate_load_addr},
-    { "lw",     0x23,  FORMAT_I, OUT_I_LOAD,    4, &FuncInstr::calculate_load_addr},
-    
-    // name    funct    format    operation   memsize           pointer
-    { "sb",     0x28,  FORMAT_I, OUT_I_STORE,   1, &FuncInstr::calculate_store_addr},
-    { "sh",     0x29,  FORMAT_I, OUT_I_STORE,   2, &FuncInstr::calculate_store_addr},
-    { "sw",     0x2B,  FORMAT_I, OUT_I_STORE,   4, &FuncInstr::calculate_store_addr},
-    
-    // name    funct    format    operation   memsize           pointer
-    { "break",  0xD,   FORMAT_R, OUT_R_SPECIAL, 0, &FuncInstr::execute_break},
-    { "syscall",0xC,   FORMAT_R, OUT_R_SPECIAL, 0, &FuncInstr::execute_syscall},
-    { "trap",   0x1A,  FORMAT_J, OUT_J_SPECIAL, 0, &FuncInstr::execute_trap},
-};                                              
+    // name    funct    format    operation     memsize           pointer
+    { "sll",    0x0,   FORMAT_R, OUT_R_SHAMT,      0, &FuncInstr::execute_sll},
+    { "srl",    0x2,   FORMAT_R, OUT_R_SHAMT,      0, &FuncInstr::execute_srl},
+    { "sra",    0x3,   FORMAT_R, OUT_R_SHAMT,      0, &FuncInstr::execute_sra},
+    { "sllv",   0x4,   FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_sllv},
+    { "srlv",   0x6,   FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_srlv},
+    { "srav",   0x7,   FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_srav},
+    { "lui",    0xF,   FORMAT_I, OUT_I_CONST,      0, &FuncInstr::execute_lui},
+    { "slt",    0x2A,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_slt},
+    { "sltu",   0x2B,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_sltu},
+    { "slti",   0xA,   FORMAT_I, OUT_I_ARITHM,     0, &FuncInstr::execute_slti},
+    { "sltiu",  0xB,   FORMAT_I, OUT_I_ARITHM,     0, &FuncInstr::execute_sltiu},
+
+    // name    funct    format    operation     memsize           pointer
+    { "and",    0x24,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_and},
+    { "or",     0x25,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_or},
+    { "xor",    0x26,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_xor},
+    { "nor",    0x27,  FORMAT_R, OUT_R_ARITHM,     0, &FuncInstr::execute_nor},
+
+    // name    funct    format    operation     memsize           pointer
+    { "andi",   0xC,   FORMAT_I, OUT_I_ARITHM,     0, &FuncInstr::execute_andi},
+    { "ori",    0xD,   FORMAT_I, OUT_I_ARITHM,     0, &FuncInstr::execute_ori},
+    { "xori",   0xE,   FORMAT_I, OUT_I_ARITHM,     0, &FuncInstr::execute_xori},
+
+    // name    funct    format    operation     memsize           pointer
+    { "beq",    0x4,   FORMAT_I, OUT_I_BRANCH,     0, &FuncInstr::execute_beq},
+    { "bne",    0x5,   FORMAT_I, OUT_I_BRANCH,     0, &FuncInstr::execute_bne},
+    { "blez",   0x6,   FORMAT_I, OUT_I_BRANCH,     0, &FuncInstr::execute_blez},
+    { "bgtz",   0x7,   FORMAT_I, OUT_I_BRANCH,     0, &FuncInstr::execute_bgtz},
+    { "jal",    0x3,   FORMAT_J, OUT_J_JUMP_LINK,  0, &FuncInstr::execute_jal},
+    { "j",      0x2,   FORMAT_J, OUT_J_JUMP,       0, &FuncInstr::execute_j},
+    { "jr",     0x8,   FORMAT_R, OUT_R_JUMP,       0, &FuncInstr::execute_jr},
+    { "jalr",   0x9,   FORMAT_R, OUT_R_JUMP_LINK,  0, &FuncInstr::execute_jalr},
+
+    // name    funct    format    operation     memsize           pointer
+    { "lb",     0x20,  FORMAT_I, OUT_I_LOAD,       1, &FuncInstr::calculate_load_addr},
+    { "lbu",    0x24,  FORMAT_I, OUT_I_LOADU,      1, &FuncInstr::calculate_load_addr},
+    { "lh",     0x21,  FORMAT_I, OUT_I_LOAD,       2, &FuncInstr::calculate_load_addr},
+    { "lhu",    0x25,  FORMAT_I, OUT_I_LOADU,      2, &FuncInstr::calculate_load_addr},
+    { "lw",     0x23,  FORMAT_I, OUT_I_LOAD,       4, &FuncInstr::calculate_load_addr},
+
+    // name    funct    format    operation     memsize           pointer
+    { "sb",     0x28,  FORMAT_I, OUT_I_STORE,      1, &FuncInstr::calculate_store_addr},
+    { "sh",     0x29,  FORMAT_I, OUT_I_STORE,      2, &FuncInstr::calculate_store_addr},
+    { "sw",     0x2B,  FORMAT_I, OUT_I_STORE,      4, &FuncInstr::calculate_store_addr},
+
+    // name    funct    format    operation     memsize           pointer
+    { "break",  0xD,   FORMAT_R, OUT_R_SPECIAL,    0, &FuncInstr::execute_break},
+    { "syscall",0xC,   FORMAT_R, OUT_R_SPECIAL,    0, &FuncInstr::execute_syscall},
+    { "trap",   0x1A,  FORMAT_J, OUT_J_SPECIAL,    0, &FuncInstr::execute_trap},
+};
 const uint32 FuncInstr::isaTableSize = countof(isaTable);
 
-const char *FuncInstr::regTable[REG_NUM_MAX] = 
+const char *FuncInstr::regTable[REG_NUM_MAX] =
 {
     "zero",
     "at",
@@ -100,7 +100,7 @@ const char *FuncInstr::regTable[REG_NUM_MAX] =
     "a0", "a1", "a2", "a3",
     "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7",
     "s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7",
-    "t8", "t9", 
+    "t8", "t9",
     "k0", "k1",
     "gp",
     "sp",
@@ -116,7 +116,7 @@ FuncInstr::FuncInstr( uint32 bytes, uint32 PC) : instr(bytes), PC(PC)
 {
     src1 = src2 = dst = REG_NUM_ZERO;
     complete = false;
-    initFormat(); 
+    initFormat();
     switch ( format)
     {
         case FORMAT_R:
@@ -139,10 +139,10 @@ std::string FuncInstr::Dump( std::string indent) const
 {
     std::ostringstream oss;
     oss << indent << disasm;
-    
+
     if ( dst != REG_NUM_ZERO && complete)
     {
-        oss << "\t [ $" << regTableName(dst) 
+        oss << "\t [ $" << regTableName(dst)
             << " = 0x" << std::hex << v_dst << "]" << std::dec;
     }
     return oss.str();
@@ -182,7 +182,7 @@ void FuncInstr::initR()
             src1 = (RegNum)instr.asR.rs;
             dst  = (RegNum)instr.asR.rd;
 
-            oss <<  " $" << regTableName(dst) 
+            oss <<  " $" << regTableName(dst)
                 << ", $" << regTableName(src1)
                 << ", $" << regTableName(src2);
             break;
@@ -195,6 +195,8 @@ void FuncInstr::initR()
                 << ", $" << regTableName(src1)
                 <<  ", " << std::dec << v_imm;
             break;
+        case OUT_R_JUMP_LINK:
+            dst = REG_NUM_RA;
         case OUT_R_JUMP:
             src1  = (RegNum)instr.asR.rs;
 
@@ -224,7 +226,7 @@ void FuncInstr::initI()
             oss << regTable[dst] << ", $"
                 << regTable[src1] << ", "
                 << std::hex << "0x" << v_imm << std::dec;
-            
+
             break;
         case OUT_I_BRANCH:
             src1 = (RegNum)instr.asI.rs;
@@ -238,7 +240,7 @@ void FuncInstr::initI()
         case OUT_I_CONST:
             dst  = (RegNum)instr.asI.rt;
 
-            oss << regTable[dst] << std::hex 
+            oss << regTable[dst] << std::hex
                 << ", 0x" << v_imm << std::dec;
             break;
 
@@ -246,12 +248,12 @@ void FuncInstr::initI()
         case OUT_I_LOADU:
             src1 = (RegNum)instr.asI.rs;
             dst  = (RegNum)instr.asI.rt;
-            
+
             oss << regTable[dst] << ", 0x"
                 << std::hex << v_imm
                 << "($" << regTable[src1] << ")" << std::dec;
             break;
-        
+
         case OUT_I_STORE:
             src2 = (RegNum)instr.asI.rt;
             src1  = (RegNum)instr.asI.rs;
@@ -269,12 +271,15 @@ void FuncInstr::initI()
 
 void FuncInstr::initJ()
 {
-    dst   = REG_NUM_ZERO;
     v_imm = instr.asJ.imm;
 
     std::ostringstream oss;
     oss << isaTable[isaNum].name << " "
-        << std::hex << "0x" <<instr.asJ.imm;
+        << std::hex << "0x" << v_imm;
+
+    if ( operation == OUT_J_JUMP_LINK)
+        dst = REG_NUM_RA;
+
     disasm = oss.str();
 }
 
@@ -297,4 +302,3 @@ std::ostream& operator<< ( std::ostream& out, const FuncInstr& instr)
 {
     return out << instr.Dump( "");
 }
-

--- a/func_sim/func_instr/func_instr.h
+++ b/func_sim/func_instr/func_instr.h
@@ -69,6 +69,7 @@ class FuncInstr
             OUT_R_ARITHM,
             OUT_R_SHAMT,
             OUT_R_JUMP,
+            OUT_R_JUMP_LINK,
             OUT_R_SPECIAL,
             OUT_I_ARITHM,
             OUT_I_BRANCH,
@@ -77,6 +78,7 @@ class FuncInstr
             OUT_I_CONST,
             OUT_I_STORE,
             OUT_J_JUMP,
+            OUT_J_JUMP_LINK,
             OUT_J_SPECIAL
         } operation;
 
@@ -119,7 +121,7 @@ class FuncInstr
 
             Format format;
             OperationType operation;
- 
+
             uint8 mem_size;
 
             void (FuncInstr::*function)(void);
@@ -148,7 +150,7 @@ class FuncInstr
         uint32 new_PC;
 
         std::string disasm;
-                                                               
+
         void initFormat();
         void initR();
         void initI();
@@ -163,48 +165,48 @@ class FuncInstr
         void execute_addiu() { v_dst = v_src1 + v_imm; }
 
         void execute_mult()  { uint64 mult_res = v_src1 * v_src2; lo = mult_res & 0xFFFFFFFF; hi = mult_res >> 0x20; };
-        void execute_multu() { uint64 mult_res = v_src1 * v_src2; lo = mult_res & 0xFFFFFFFF; hi = mult_res >> 0x20; };            
+        void execute_multu() { uint64 mult_res = v_src1 * v_src2; lo = mult_res & 0xFFFFFFFF; hi = mult_res >> 0x20; };
         void execute_div()   { lo = v_src2 / v_src1; hi = v_src2 % v_src1; };
-        void execute_divu()  { lo = v_src2 / v_src1; hi = v_src2 % v_src1; };   
-        void execute_mfhi()  { v_dst = hi; };   
-        void execute_mthi()  { hi = v_src2; };   
-        void execute_mflo()  { v_dst = lo; };   
-        void execute_mtlo()  { lo = v_src2;};   
+        void execute_divu()  { lo = v_src2 / v_src1; hi = v_src2 % v_src1; };
+        void execute_mfhi()  { v_dst = hi; };
+        void execute_mthi()  { hi = v_src2; };
+        void execute_mflo()  { v_dst = lo; };
+        void execute_mtlo()  { lo = v_src2;};
 
         void execute_sll()   { v_dst = v_src1 << v_imm; }
         void execute_srl()   { v_dst = v_src1 >> v_imm; }
-        void execute_sra()   { v_dst = v_src1 >> v_imm; };    
-        void execute_sllv()  { v_dst = v_src1 << v_src2; };   
-        void execute_srlv()  { v_dst = v_src1 >> v_src2; };   
-        void execute_srav()  { v_dst = v_src1 >> v_src2; };   
+        void execute_sra()   { v_dst = v_src1 >> v_imm; };
+        void execute_sllv()  { v_dst = v_src1 << v_src2; };
+        void execute_srlv()  { v_dst = v_src1 >> v_src2; };
+        void execute_srav()  { v_dst = v_src1 >> v_src2; };
         void execute_lui()   { v_dst = v_imm  << 0x10; }
-        void execute_slt()   { v_dst = v_src2 < v_src1; };    
-        void execute_sltu()  { v_dst = v_src2 < v_src1; };   
-        void execute_slti()  { v_dst = v_src2 < instr.asI.imm; };   
-        void execute_sltiu() { v_dst = v_src2 < instr.asI.imm; };   
+        void execute_slt()   { v_dst = v_src2 < v_src1; };
+        void execute_sltu()  { v_dst = v_src2 < v_src1; };
+        void execute_slti()  { v_dst = v_src2 < instr.asI.imm; };
+        void execute_sltiu() { v_dst = v_src2 < instr.asI.imm; };
 
         void execute_and()   { v_dst = v_src1 & v_src2; }
         void execute_or()    { v_dst = v_src1 | v_src2; }
         void execute_xor()   { v_dst = v_src1 ^ v_src2; }
         void execute_nor()   { v_dst = ~( v_src1 | v_src2); }
-       
+
         void execute_andi()  { v_dst = v_src1 & v_imm; }
         void execute_ori()   { v_dst = v_src1 | v_imm; }
         void execute_xori()  { v_dst = v_src1 ^ v_imm; }
 
         void execute_beq()    { if (v_src1 == v_src2) new_PC += ((int16)v_imm << 2); }
         void execute_bne()    { if (v_src1 != v_src2) new_PC += ((int16)v_imm << 2); }
-        
-        void execute_blez()   { if (v_src1 <= 0) new_PC += ((int16)v_imm << 2); }; 
-        void execute_bgtz()   { if (v_src1 <= v_src2) new_PC += ((int16)v_imm << 2); }; 
-        void execute_jal()    { v_dst = new_PC; new_PC = (PC & 0xF0000000) | (v_imm << 2); };    
+
+        void execute_blez()   { if (v_src1 <= 0) new_PC += ((int16)v_imm << 2); };
+        void execute_bgtz()   { if (v_src1 <= v_src2) new_PC += ((int16)v_imm << 2); };
+        void execute_jal()    { v_dst = new_PC; new_PC = (PC & 0xF0000000) | (v_imm << 2); };
 
         void execute_j()      { new_PC = (PC & 0xf0000000) | (v_imm << 2); }
         void execute_jr()     { new_PC = v_src1; }
-        void execute_jalr()   { v_dst = new_PC; new_PC = v_src2; };   
+        void execute_jalr()   { v_dst = new_PC; new_PC = v_src2; };
 
         void execute_syscall(){ };
-        void execute_break()  { }; 
+        void execute_break()  { };
         void execute_trap()   { };
 
         void execute_unknown();
@@ -223,10 +225,12 @@ class FuncInstr
         RegNum get_src1_num() const { return src1; }
         RegNum get_src2_num() const { return src2; }
         RegNum get_dst_num()  const { return dst;  }
-      
+
         /* Checks if instruction can change PC in unusual way. */
-        bool isJump() const { return operation == OUT_J_JUMP ||
-                                     operation == OUT_R_JUMP ||
+        bool isJump() const { return operation == OUT_J_JUMP      ||
+                                     operation == OUT_J_JUMP_LINK ||
+                                     operation == OUT_R_JUMP      ||
+                                     operation == OUT_R_JUMP_LINK ||
                                      operation == OUT_I_BRANCH; }
         bool is_load()  const { return operation == OUT_I_LOAD || operation == OUT_I_LOADU; }
         bool is_store() const { return operation == OUT_I_STORE; }
@@ -235,18 +239,17 @@ class FuncInstr
         void set_v_src2(uint32 value) { v_src2 = value; }
 
         uint32 get_v_dst() const { return v_dst; }
-        
+
         uint32 get_mem_addr() const { return mem_addr; }
         uint32 get_mem_size() const { return mem_size; }
         uint32 get_new_PC() const { return new_PC; }
- 
+
         void set_v_dst(uint32 value)  { v_dst  = value; } // for loads
         uint32 get_v_src2() const { return v_src2; } // for stores
-	
+
         void execute() { (this->*isaTable[isaNum].function)(); complete = true; };
 };
 
 std::ostream& operator<<( std::ostream& out, const FuncInstr& instr);
 
 #endif //FUNC_INSTR_H
-


### PR DESCRIPTION
This fixes #73. Now `jal` and `jalr` instructions are saving `PC + 4` into `$31` register