### PR TITLE
Encapsulate LRUCache internals

### DIFF
--- a/simulator/infra/instrcache/LRUCache.h
+++ b/simulator/infra/instrcache/LRUCache.h
@@ -19,30 +19,16 @@ class LRUCache
         LRUCache() { data.reserve( CAPACITY); }
 
         static auto get_capacity() { return CAPACITY; }
-        
-        auto begin() const { return data.cbegin(); }
-        auto end() const { return data.cend(); }
-        auto find( const Key& key) const { return data.find( key); }
-        
-        std::size_t size() const { return number_of_elements; }
-        bool empty() const { return number_of_elements == 0u; }
 
-        void allocate( const Key& key, const Value& value) {
-            if ( number_of_elements == CAPACITY)
-            {
-                // Delete least recently used element
-                const auto& lru_elem = lru_list.back();
-                lru_hash.erase( lru_elem);
-                data.erase( lru_elem);
-                lru_list.pop_back();
-            }
-            else {
-                 number_of_elements++;
-            }
-            // Add a new element
-            data.emplace( key, value);
-            auto ptr = lru_list.insert( lru_list.begin(), key);
-            lru_hash.emplace( key, ptr);
+        auto size() const { return number_of_elements; }
+        bool empty() const { return size() == 0; }
+
+        // First return value is true if and only if the value was found
+        // Second return value is not dereferenceable if first value if 'false'
+        auto find( const Key& key) const
+        {
+            auto result = data.find( key);
+            return std::pair<bool, const Value&>( result != data.end(), result->second);
         }
 
         void update( const Key& key, const Value& value)
@@ -68,7 +54,7 @@ class LRUCache
             assert ( ( data_it == data.end()) == ( lru_it == lru_hash.end()));
             if ( data_it != data.end())
             {
-                assert( number_of_elements > 0);
+                assert( !empty());
                 data.erase( data_it);
                 lru_list.erase( lru_it->second);
                 lru_hash.erase( lru_it);
@@ -78,6 +64,25 @@ class LRUCache
         }
 
     private:
+        void allocate( const Key& key, const Value& value)
+        {
+            if ( number_of_elements == CAPACITY)
+            {
+                // Delete least recently used element
+                const auto& lru_elem = lru_list.back();
+                lru_hash.erase( lru_elem);
+                data.erase( lru_elem);
+                lru_list.pop_back();
+            }
+            else {
+                 number_of_elements++;
+            }
+            // Add a new element
+            data.emplace( key, value);
+            auto ptr = lru_list.insert( lru_list.begin(), key);
+            lru_hash.emplace( key, ptr);
+        }
+
         std::unordered_map<Key, Value> data{};
 
         std::list<Key> lru_list{};

--- a/simulator/infra/instrcache/LRUCache.h
+++ b/simulator/infra/instrcache/LRUCache.h
@@ -24,7 +24,7 @@ class LRUCache
         bool empty() const { return size() == 0; }
 
         // First return value is true if and only if the value was found
-        // Second return value is not dereferenceable if first value if 'false'
+        // Second return value is dereferenceable only if first value if 'true'
         auto find( const Key& key) const
         {
             auto result = data.find( key);

--- a/simulator/infra/instrcache/t/unit_test.cpp
+++ b/simulator/infra/instrcache/t/unit_test.cpp
@@ -26,6 +26,10 @@ public:
     explicit Dummy( uint32 val) : value( val) {};
     bool is_same( const Dummy& rhs) const { return value == rhs.value; }
     bool operator==( const Dummy& rhs) const { return is_same(rhs); }
+    friend std::ostream& operator<<( std::ostream& out, const Dummy& val)
+    {
+        return out << val.value;
+    }
 };
 
 TEST( update_and_find_int, Update_Find_And_Check_Using_Int)
@@ -36,11 +40,10 @@ TEST( update_and_find_int, Update_Find_And_Check_Using_Int)
     const Dummy test_number( 0x103abf9);
 
     cache.update( PC, test_number);
-    auto it = cache.find( PC);
+    auto result = cache.find( PC);
 
-    ASSERT_TRUE( it != cache.end());
-    ASSERT_EQ( it->first, PC);
-    ASSERT_EQ( it->second, test_number);
+    ASSERT_TRUE( result.first);
+    ASSERT_EQ( result.second, test_number);
 }
 
 TEST( update_and_find, Update_Find_And_Check)
@@ -52,7 +55,7 @@ TEST( update_and_find, Update_Find_And_Check)
     const FuncInstr instr( instr_bytes, PC);
 
     instr_cache.update( PC, instr);
-    ASSERT_TRUE( instr_cache.find( PC) != instr_cache.end());
+    ASSERT_TRUE( instr_cache.find( PC).first);
 }
 
 TEST( check_method_erase, Check_Method_Erase)
@@ -66,7 +69,7 @@ TEST( check_method_erase, Check_Method_Erase)
     instr_cache.update( PC, instr);
     instr_cache.erase( PC);
 
-    ASSERT_TRUE( instr_cache.find( PC) == instr_cache.end());
+    ASSERT_FALSE( instr_cache.find( PC).first);
 }
 
 TEST( check_method_empty, Check_Method_Empty)
@@ -118,7 +121,7 @@ TEST( exceed_capacity_and_test_lru, Add_More_Elements_Than_Capacity_And_Check)
 
     ASSERT_EQ( cache.size(), CAPACITY);
     ASSERT_FALSE( cache.empty());
-    ASSERT_TRUE( cache.find( 2) == cache.end());
+    ASSERT_FALSE( cache.find( 2).first);
 }
 
 

--- a/simulator/mips/mips_memory.cpp
+++ b/simulator/mips/mips_memory.cpp
@@ -9,16 +9,14 @@
 #include <infra/instrcache/instr_cache.h>
 
 #include <iostream>
+
 FuncInstr MIPSMemory::fetch_instr( Addr PC)
 {
-    auto it = instr_cache.find( PC);
+    const auto& [found, value] = instr_cache.find( PC);
 
-    FuncInstr instr = ( it != instr_cache.end())
-                      ? FuncInstr( it->second)
-                      : FuncInstr( read( PC), PC);
+    FuncInstr instr = found ? value : FuncInstr( fetch( PC), PC);
 
-    if ( it != instr_cache.end())
-        instr_cache.update( PC, instr);
-        
+    instr_cache.update( PC, instr);
+
     return instr;    
 }


### PR DESCRIPTION
Iterator is not the thing we want to provide to LRUCache users. It is safer to return pair of bool and rvalue reference (or std::optional, but I find its interface confusing).