### PR TITLE
Use uint32 bitfield identifiers to match instr size.

### DIFF
--- a/simulator/mips/mips_instr.h
+++ b/simulator/mips/mips_instr.h
@@ -113,24 +113,24 @@ class FuncInstr
         {
             const struct
             {
-                unsigned funct  :6;
-                unsigned shamt  :5;
-                unsigned rd     :5;
-                unsigned rt     :5;
-                unsigned rs     :5;
-                unsigned opcode :6;
+                uint32 funct  :6;
+                uint32 shamt  :5;
+                uint32 rd     :5;
+                uint32 rt     :5;
+                uint32 rs     :5;
+                uint32 opcode :6;
             } asR;
             const struct
             {
-                unsigned imm    :16;
-                unsigned rt     :5;
-                unsigned rs     :5;
-                unsigned opcode :6;
+                uint32 imm    :16;
+                uint32 rt     :5;
+                uint32 rs     :5;
+                uint32 opcode :6;
             } asI;
             const struct
             {
-                unsigned imm    :26;
-                unsigned opcode :6;
+                uint32 imm    :26;
+                uint32 opcode :6;
             } asJ;
           
             const uint32 raw;


### PR DESCRIPTION
Although allocation and alignment of bit-ﬁelds within a class object is implementation-deﬁned, they're usually taking the size not less than the field identifier type takes. Previously used "unsigned" identifier usually has "sizeof(unsigned)==4", which is fortunately the same as "sizeof(uint32)" (the other representation of the union "instr" - "uint32 raw"). To avoid cases then "sizeof(unsigned)!=4" (and "asR", "asI", "asJ" could take not 32 bits), the same type identifiers were used for the all members of the union.