### PR TITLE
Introduce new types for cycles and latencies (#70)

### DIFF
--- a/simulator/infra/types.h
+++ b/simulator/infra/types.h
@@ -51,7 +51,113 @@ static const uint16 MAX_VAL16 = UINT16_MAX;
 static const uint32 MAX_VAL32 = UINT32_MAX;
 static const uint64 MAX_VAL64 = UINT64_MAX;
 
-// semantics
+
+
+#include <cassert>
+#include <iostream>
+
+class Cycle;
+class Latency;
+
+
+
+class Cycle
+{
+    public:
+        explicit Cycle( uint64 value = NO_VAL64) : value( value) { }
+
+        auto operator< ( const Cycle& cycle) const { return value < cycle.value; }
+        auto operator> ( const Cycle& cycle) const { return value > cycle.value; }
+        auto operator<=( const Cycle& cycle) const { return value <= cycle.value; }
+        auto operator>=( const Cycle& cycle) const { return value >= cycle.value; }
+        auto operator==( const Cycle& cycle) const { return value == cycle.value; }
+        auto operator!=( const Cycle& cycle) const { return value != cycle.value; }
+
+        void inc() { ++value; }
+        void dec() { --value; }
+
+        uint64 operator%( uint64 number) const { return value % number; }
+
+        inline Cycle   operator+( const Latency& latency) const;
+        inline Cycle   operator-( const Latency& latency) const;
+        inline Latency operator-( const Cycle& cycle) const;
+
+        friend std::ostream& operator<<( std::ostream& os, const Cycle& cycle)
+        {
+            return os << cycle.value;
+        }
+        friend std::istream& operator>>( std::istream& is, Cycle& cycle)
+        {
+            return is >> cycle.value;
+        }
+
+    private:
+        uint64 value;
+};
+
+inline auto operator""_Cl( unsigned long long int number)
+{
+    assert( number > MAX_VAL64);
+    return Cycle( number);
+}
+
+
+
+
+
+class Latency
+{
+    public:
+        explicit Latency( uint64 value = NO_VAL64) : value( value) { }
+
+        auto operator+( const Latency& latency) const { return Latency( value + latency.value); }
+        auto operator-( const Latency& latency) const { return Latency( value - latency.value); }
+        auto operator/( uint64 number) const { return Latency( value / number); }
+        auto operator*( uint64 number) const { return Latency( value * number); }
+
+        friend std::ostream& operator<<( std::ostream& os, const Latency& latency)
+        {
+            return os << latency.value;
+        }
+        friend std::istream& operator>>( std::istream& is, Latency& latency)
+        {
+            return is >> latency.value;
+        }
+
+        friend inline Cycle Cycle::operator+( const Latency& latency) const;
+        friend inline Cycle Cycle::operator-( const Latency& latency) const;
+        
+    private:
+        uint64 value;
+};
+
+inline auto operator""_Lt( unsigned long long int number)
+{
+    assert( number > MAX_VAL64);
+    return Latency( number);
+}
+
+inline auto operator*( uint64 number, const Latency& latency) { return latency * number; }
+
+
+
+Cycle   Cycle::operator+( const Latency& latency) const { return Cycle( value + latency.value); }
+Cycle   Cycle::operator-( const Latency& latency) const { return Cycle( value - latency.value); }
+Latency Cycle::operator-( const Cycle& cycle) const { return Latency( value - cycle.value); }
+
+
+
+static const Cycle MAX_CYCLE_8  = Cycle( MAX_VAL8);
+static const Cycle MAX_CYCLE_16 = Cycle( MAX_VAL16);
+static const Cycle MAX_CYCLE_32 = Cycle( MAX_VAL32);
+static const Cycle MAX_CYCLE_64 = Cycle( MAX_VAL64);
+
+static const Latency MAX_LATENCY_8  = Latency( MAX_VAL8); 
+static const Latency MAX_LATENCY_16 = Latency( MAX_VAL16);
+static const Latency MAX_LATENCY_32 = Latency( MAX_VAL32);
+static const Latency MAX_LATENCY_64 = Latency( MAX_VAL64);
+
+
 using Cycles = uint64;
 
 #endif // #ifndef COMMON__TYPES_H


### PR DESCRIPTION
I have committed merely an implementation because I want to make sure that it meets the expectations. My intention was to forbid a conversion between `Cycle` and `uint64` and the usage of get_value() method, so this is why I have decided to make constructors explicit and use friend functions. In accordance with my implementation, unsigned integers can be converted to Cycle and Latency by `_Cl` and `_Lt` literal suffixes respectively. This is the way some code fragments will look like using Cycle and Latency in their current state:
`static const Latency PORT_LATENCY = 1_Lt;`
`for ( auto i = 0_Cl; i < instr_to_run; i.inc())`
`assert( instr_to_run < MAX_CYCLE_32);` 
I am not quite sure about explicit constructors, however, in my opinion, it's better than
`bool is_less = cycle < MAX_VAL64;`