### PR TITLE
Introduce new types to ports and perf_sim and fix problems(#70)

### DIFF
--- a/simulator/core/perf_sim.cpp
+++ b/simulator/core/perf_sim.cpp
@@ -104,8 +104,8 @@ void PerfMIPS::run( const std::string& tr,
     auto t_end = std::chrono::high_resolution_clock::now();
 
     auto time = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-    auto frequency = cycle / time; // cycles per millisecond = kHz
-    auto ipc = 1.0 * executed_instrs / cycle;
+    auto frequency = static_cast<double>( cycle) / time; // cycles per millisecond = kHz
+    auto ipc = 1.0 * executed_instrs / static_cast<double>( cycle);
     auto simips = executed_instrs / time;
 
     std::cout << std::endl << "****************************"
@@ -300,7 +300,7 @@ void PerfMIPS::clock_writeback( Cycle cycle)
     if ( !rp_memory_2_writeback->is_ready( cycle))
     {
         sout << "bubble\n";
-        if ( 0_Cl + (cycle - last_writeback_cycle) >= 10_Cl)
+        if ( cycle >= last_writeback_cycle + 10_Lt)
         {
             serr << "Deadlock was detected. The process will be aborted."
                  << std::endl << std::endl << critical;

--- a/simulator/core/perf_sim.cpp
+++ b/simulator/core/perf_sim.cpp
@@ -8,7 +8,7 @@
 
 #include "perf_sim.h"
 
-static const uint32 PORT_LATENCY = 1;
+static const Latency PORT_LATENCY = 1_Lt;
 static const uint32 PORT_FANOUT = 1;
 static const uint32 PORT_BW = 1;
 static const uint32 FLUSHED_STAGES_NUM = 4;
@@ -56,7 +56,7 @@ PerfMIPS::PerfMIPS(bool log) : Log( log), rf( new RF), checker( false)
     init_ports();
 }
 
-FuncInstr PerfMIPS::read_instr(uint64 cycle)
+FuncInstr PerfMIPS::read_instr( Cycle cycle)
 {
     if (rp_decode_2_decode->is_ready( cycle))
     {
@@ -76,7 +76,7 @@ void PerfMIPS::run( const std::string& tr,
                     uint64 instrs_to_run)
 {
     assert( instrs_to_run < MAX_VAL32);
-    Cycles cycle = 0;
+    Cycle cycle = 0_Cl;
 
     memory = new MIPSMemory( tr);
 
@@ -93,7 +93,7 @@ void PerfMIPS::run( const std::string& tr,
         clock_decode( cycle);
         clock_execute( cycle);
         clock_memory( cycle);
-        ++cycle;
+        cycle.inc();
 
         sout << "Executed instructions: " << executed_instrs
              << std::endl << std::endl;
@@ -119,7 +119,7 @@ void PerfMIPS::run( const std::string& tr,
               << std::endl;
 }
 
-void PerfMIPS::clock_fetch( int cycle)
+void PerfMIPS::clock_fetch( Cycle cycle)
 {
     /* receive flush and stall signals */
     const bool is_flush = rp_fetch_flush->is_ready( cycle) && rp_fetch_flush->read( cycle);
@@ -153,7 +153,7 @@ void PerfMIPS::clock_fetch( int cycle)
          << std::hex << PC << ": 0x" << data.raw << std::endl;
 }
 
-void PerfMIPS::clock_decode( int cycle)
+void PerfMIPS::clock_decode( Cycle cycle)
 {
     sout << "decode  cycle " << std::dec << cycle << ": ";
 
@@ -197,7 +197,7 @@ void PerfMIPS::clock_decode( int cycle)
     }
 }
 
-void PerfMIPS::clock_execute( int cycle)
+void PerfMIPS::clock_execute( Cycle cycle)
 {
     sout << "execute cycle " << std::dec << cycle << ": ";
 
@@ -235,7 +235,7 @@ void PerfMIPS::clock_execute( int cycle)
     sout << instr << std::endl;
 }
 
-void PerfMIPS::clock_memory( int cycle)
+void PerfMIPS::clock_memory( Cycle cycle)
 {
     sout << "memory  cycle " << std::dec << cycle << ": ";
 
@@ -292,7 +292,7 @@ void PerfMIPS::clock_memory( int cycle)
     sout << instr << std::endl;
 }
 
-void PerfMIPS::clock_writeback( int cycle)
+void PerfMIPS::clock_writeback( Cycle cycle)
 {
     sout << "wb      cycle " << std::dec << cycle << ": ";
 
@@ -300,7 +300,7 @@ void PerfMIPS::clock_writeback( int cycle)
     if ( !rp_memory_2_writeback->is_ready( cycle))
     {
         sout << "bubble\n";
-        if ( cycle - last_writeback_cycle >= 10)
+        if ( 0_Cl + (cycle - last_writeback_cycle) >= 10_Cl)
         {
             serr << "Deadlock was detected. The process will be aborted."
                  << std::endl << std::endl << critical;

--- a/simulator/core/perf_sim.h
+++ b/simulator/core/perf_sim.h
@@ -23,7 +23,7 @@ class PerfMIPS : protected Log
 {
 private:
     Cycles executed_instrs = 0;
-    Cycles last_writeback_cycle = 0; // to handle possible deadlocks
+    Cycle last_writeback_cycle = 0_Cl; // to handle possible deadlocks
 
     /* the struture of data sent from fetch to decode stage */
     struct IfIdData {
@@ -73,12 +73,12 @@ private:
     std::unique_ptr<ReadPort<Addr>> rp_memory_2_fetch_target = nullptr;
 
     /* main stages functions */
-    void clock_fetch( int cycle);
-    void clock_decode( int cycle);
-    void clock_execute( int cycle);
-    void clock_memory( int cycle);
-    void clock_writeback( int cycle);
-    FuncInstr read_instr(uint64 cycle);
+    void clock_fetch( Cycle cycle);
+    void clock_decode( Cycle cycle);
+    void clock_execute( Cycle cycle);
+    void clock_memory( Cycle cycle);
+    void clock_writeback( Cycle cycle);
+    FuncInstr read_instr( Cycle cycle);
 
 public:
     explicit PerfMIPS( bool log);

--- a/simulator/core/perf_sim.h
+++ b/simulator/core/perf_sim.h
@@ -22,7 +22,7 @@
 class PerfMIPS : protected Log
 {
 private:
-    Cycles executed_instrs = 0;
+    uint64 executed_instrs = 0;
     Cycle last_writeback_cycle = 0_Cl; // to handle possible deadlocks
 
     /* the struture of data sent from fetch to decode stage */

--- a/simulator/infra/ports/ports.cpp
+++ b/simulator/infra/ports/ports.cpp
@@ -14,7 +14,7 @@ void init_ports()
         map->init();
 }
 
-void check_ports( uint64 cycle)
+void check_ports( Cycle cycle)
 {
     for ( auto map : BasePort::BaseMap::all_maps)
         map->check( cycle);

--- a/simulator/infra/ports/ports.h
+++ b/simulator/infra/ports/ports.h
@@ -192,7 +192,7 @@ template<class T> class ReadPort: public Port<T>
         struct Cell
         {
             T data = T();
-            Cycle cycle = 0;
+            Cycle cycle = 0_Cl;
             Cell() = delete;
             Cell( T v, Cycle c) : data( std::move( v)), cycle( c) { }
         };

--- a/simulator/infra/ports/ports.h
+++ b/simulator/infra/ports/ports.h
@@ -28,24 +28,24 @@ template<class T> class WritePort;
 
 // Global port handlers
 extern void init_ports();
-extern void check_ports( uint64 cycle);
+extern void check_ports( Cycle cycle);
 extern void destroy_ports();
 
 class BasePort : protected Log
 {
         friend void init_ports();
-        friend void check_ports( uint64 cycle);
+        friend void check_ports( Cycle cycle);
         friend void destroy_ports();
 
     protected:
         class BaseMap : public Log
         {
                 friend void init_ports();
-                friend void check_ports( uint64 cycle);
+                friend void check_ports( Cycle cycle);
                 friend void destroy_ports();
 
                 virtual void init() const = 0;
-                virtual void check( uint64 cycle) const = 0;
+                virtual void check( Cycle cycle) const = 0;
                 virtual void destroy() = 0;
 
                 static std::list<BaseMap*> all_maps;
@@ -91,7 +91,7 @@ template<class T> class Port : public BasePort
             void init() const final;
 
             // Finding lost elements
-            void check( uint64 cycle) const final;
+            void check( Cycle cycle) const final;
 
             // Destroy connections
             void destroy() final;
@@ -136,12 +136,12 @@ template<class T> class WritePort : public Port<T>
         ReadListType _destinations = {};
 
         // Variables for counting token in the last cycle
-        uint64 _lastCycle = 0;
+        Cycle _lastCycle = 0_Cl;
         uint32 _writeCounter = 0;
 
         void init( const ReadListType& readers);
 
-        void check( uint64 cycle) const {
+        void check( Cycle cycle) const {
             for ( const auto& reader : _destinations)
                 reader->check( cycle);
         }
@@ -169,7 +169,7 @@ template<class T> class WritePort : public Port<T>
         }
 
         // Write Method
-        void write( const T& what, uint64 cycle);
+        void write( const T& what, Cycle cycle);
 
         // Returns fanout for test of connection
         uint32 getFanout() const { return _fanout; }
@@ -186,26 +186,26 @@ template<class T> class ReadPort: public Port<T>
         using Log::critical;
 
         // Latency is the number of cycles after which we may take data from port.
-        const uint64 _latency;
+        const Latency _latency;
 
         // Queue of data that should be released
         struct Cell
         {
             T data = T();
-            uint64 cycle = 0;
+            Cycle cycle = 0;
             Cell() = delete;
-            Cell( T v, uint64 c) : data( std::move( v)), cycle( c) { }
+            Cell( T v, Cycle c) : data( std::move( v)), cycle( c) { }
         };
         std::queue<Cell> _dataQueue;
 
         // Pushes data from WritePort
-        void pushData( const T& what, uint64 cycle)
+        void pushData( const T& what, Cycle cycle)
         {
              _dataQueue.emplace( what, cycle + _latency); // NOTE: we copy data here
         }
 
         // Tests if there is any ungot data
-        void check( uint64 cycle) const;
+        void check( Cycle cycle) const;
     public:
         /*
          * Constructor
@@ -215,20 +215,20 @@ template<class T> class ReadPort: public Port<T>
          *
          * Adds port to needed Map.
         */
-        ReadPort<T>( std::string key, uint64 latency) :
+        ReadPort<T>( std::string key, Latency latency) :
             Port<T>::Port( std::move( key)), _latency( latency), _dataQueue()
         {
             this->portMap[ this->_key].readers.push_front( this);
         }
 
         // Is ready? method
-        bool is_ready( uint64 cycle) const;
+        bool is_ready( Cycle cycle) const;
 
         // Read method
-        T read( uint64 cycle);
+        T read( Cycle cycle);
 
         // Read but ignore the data
-        void ignore( uint64 cycle);
+        void ignore( Cycle cycle);
 };
 
 /*
@@ -242,7 +242,7 @@ template<class T> class ReadPort: public Port<T>
  * If port wasn't initialized, asserts.
  * If port is overloaded by bandwidth (more than _bandwidth token during one cycle, asserts).
 */
-template<class T> void WritePort<T>::write( const T& what, uint64 cycle)
+template<class T> void WritePort<T>::write( const T& what, Cycle cycle)
 {
     if ( !this->_init)
     {
@@ -326,7 +326,7 @@ template<class T> void WritePort<T>::destroy()
  * If succesful, returns true
  * If uninitalized, generates error
 */
-template<class T> bool ReadPort<T>::is_ready( uint64 cycle) const
+template<class T> bool ReadPort<T>::is_ready( Cycle cycle) const
 {
     if ( !this->_init)
     {
@@ -345,7 +345,7 @@ template<class T> bool ReadPort<T>::is_ready( uint64 cycle) const
  *
  * If there was nothing to read, generates error (use is_ready before reading)
 */
-template<class T> T ReadPort<T>::read( uint64 cycle)
+template<class T> T ReadPort<T>::read( Cycle cycle)
 {
     if ( !this->_init)
         serr << this->_key << " ReadPort was not initializated" << std::endl << critical;
@@ -364,7 +364,7 @@ template<class T> T ReadPort<T>::read( uint64 cycle)
  *
  * Reads all data which should be read in this cycle but does not copy it
  */
-template<class T> void ReadPort<T>::ignore( uint64 cycle)
+template<class T> void ReadPort<T>::ignore( Cycle cycle)
 {
     while ( this->is_ready( cycle))
          _dataQueue.pop();
@@ -373,7 +373,7 @@ template<class T> void ReadPort<T>::ignore( uint64 cycle)
 /*
  * Tests if there is any data that can not be used ever.
 */
-template<class T> void ReadPort<T>::check(uint64 cycle) const
+template<class T> void ReadPort<T>::check( Cycle cycle) const
 {
     if ( !_dataQueue.empty() && _dataQueue.front().cycle < cycle)
         serr << "In " << this->_key << " port data was added at "
@@ -418,10 +418,10 @@ template<class T> void Port<T>::Map::destroy()
  * Argument is the number of current cycle.
  * If some token couldn't be get in future, warnings
 */
-template<class T> void Port<T>::Map::check( uint64 cycle) const
+template<class T> void Port<T>::Map::check( Cycle cycle) const
 {
     for ( const auto& cluster : _map)
-        cluster.second.writer->check(cycle);
+        cluster.second.writer->check( cycle);
 }
 
 // External methods

--- a/simulator/infra/types.h
+++ b/simulator/infra/types.h
@@ -74,7 +74,7 @@ class Cycle
         auto operator!=( const Cycle& cycle) const { return value != cycle.value; }
 
         void inc() { ++value; }
-        operator double() const { return static_cast<double>( value); }
+        explicit operator double() const { return static_cast<double>( value); }
 
         uint64 operator%( uint64 number) const { return value % number; }
 
@@ -145,7 +145,5 @@ Cycle   Cycle::operator+( const Latency& latency) const { return Cycle( value + 
 Cycle   Cycle::operator-( const Latency& latency) const { return Cycle( value - latency.value); }
 Latency Cycle::operator-( const Cycle& cycle) const { return Latency( value - cycle.value); }
 
-
-using Cycles = uint64;
 
 #endif // #ifndef COMMON__TYPES_H

--- a/simulator/infra/types.h
+++ b/simulator/infra/types.h
@@ -74,7 +74,7 @@ class Cycle
         auto operator!=( const Cycle& cycle) const { return value != cycle.value; }
 
         void inc() { ++value; }
-        void dec() { --value; }
+        operator double() const { return static_cast<double>( value); }
 
         uint64 operator%( uint64 number) const { return value % number; }
 
@@ -97,7 +97,7 @@ class Cycle
 
 inline auto operator""_Cl( unsigned long long int number)
 {
-    assert( number > MAX_VAL64);
+    assert( number <= MAX_VAL64);
     return Cycle( number);
 }
 
@@ -133,7 +133,7 @@ class Latency
 
 inline auto operator""_Lt( unsigned long long int number)
 {
-    assert( number > MAX_VAL64);
+    assert( number <= MAX_VAL64);
     return Latency( number);
 }
 
@@ -144,18 +144,6 @@ inline auto operator*( uint64 number, const Latency& latency) { return latency *
 Cycle   Cycle::operator+( const Latency& latency) const { return Cycle( value + latency.value); }
 Cycle   Cycle::operator-( const Latency& latency) const { return Cycle( value - latency.value); }
 Latency Cycle::operator-( const Cycle& cycle) const { return Latency( value - cycle.value); }
-
-
-
-static const Cycle MAX_CYCLE_8  = Cycle( MAX_VAL8);
-static const Cycle MAX_CYCLE_16 = Cycle( MAX_VAL16);
-static const Cycle MAX_CYCLE_32 = Cycle( MAX_VAL32);
-static const Cycle MAX_CYCLE_64 = Cycle( MAX_VAL64);
-
-static const Latency MAX_LATENCY_8  = Latency( MAX_VAL8); 
-static const Latency MAX_LATENCY_16 = Latency( MAX_VAL16);
-static const Latency MAX_LATENCY_32 = Latency( MAX_VAL32);
-static const Latency MAX_LATENCY_64 = Latency( MAX_VAL64);
 
 
 using Cycles = uint64;

--- a/simulator/infra/types.h
+++ b/simulator/infra/types.h
@@ -51,7 +51,113 @@ static const uint16 MAX_VAL16 = UINT16_MAX;
 static const uint32 MAX_VAL32 = UINT32_MAX;
 static const uint64 MAX_VAL64 = UINT64_MAX;
 
-// semantics
+
+
+#include <cassert>
+#include <iostream>
+
+class Cycle;
+class Latency;
+
+
+
+class Cycle
+{
+    public:
+        explicit Cycle( uint64 value = NO_VAL64) : value( value) { }
+
+        auto operator< ( const Cycle& cycle) const { return value < cycle.value; }
+        auto operator> ( const Cycle& cycle) const { return value > cycle.value; }
+        auto operator<=( const Cycle& cycle) const { return value <= cycle.value; }
+        auto operator>=( const Cycle& cycle) const { return value >= cycle.value; }
+        auto operator==( const Cycle& cycle) const { return value == cycle.value; }
+        auto operator!=( const Cycle& cycle) const { return value != cycle.value; }
+
+        void inc() { ++value; }
+        void dec() { --value; }
+
+        uint64 operator%( uint64 number) const { return value % number; }
+
+        inline Cycle   operator+( const Latency& latency) const;
+        inline Cycle   operator-( const Latency& latency) const;
+        inline Latency operator-( const Cycle& cycle) const;
+
+        friend std::ostream& operator<<( std::ostream& os, const Cycle& cycle)
+        {
+            return os << cycle.value;
+        }
+        friend std::istream& operator>>( std::istream& is, Cycle& cycle)
+        {
+            return is >> cycle.value;
+        }
+
+    private:
+        uint64 value;
+};
+
+inline auto operator""_Cl( unsigned long long int number)
+{
+    assert( number > MAX_VAL64);
+    return Cycle( number);
+}
+
+
+
+
+
+class Latency
+{
+    public:
+        explicit Latency( uint64 value = NO_VAL64) : value( value) { }
+
+        auto operator+( const Latency& latency) const { return Latency( value + latency.value); }
+        auto operator-( const Latency& latency) const { return Latency( value - latency.value); }
+        auto operator/( uint64 number) const { return Latency( value / number); }
+        auto operator*( uint64 number) const { return Latency( value * number); }
+
+        friend std::ostream& operator<<( std::ostream& os, const Latency& latency)
+        {
+            return os << latency.value;
+        }
+        friend std::istream& operator>>( std::istream& is, Latency& latency)
+        {
+            return is >> latency.value;
+        }
+
+        friend inline Cycle Cycle::operator+( const Latency& latency) const;
+        friend inline Cycle Cycle::operator-( const Latency& latency) const;
+        
+    private:
+        uint64 value;
+};
+
+inline auto operator""_Lt( unsigned long long int number)
+{
+    assert( number > MAX_VAL64);
+    return Latency( number);
+}
+
+inline auto operator*( uint64 number, const Latency& latency) { return latency * number; }
+
+
+
+Cycle   Cycle::operator+( const Latency& latency) const { return Cycle( value + latency.value); }
+Cycle   Cycle::operator-( const Latency& latency) const { return Cycle( value - latency.value); }
+Latency Cycle::operator-( const Cycle& cycle) const { return Latency( value - cycle.value); }
+
+
+
+static const Cycle MAX_CYCLE_8  = Cycle( MAX_VAL8);
+static const Cycle MAX_CYCLE_16 = Cycle( MAX_VAL16);
+static const Cycle MAX_CYCLE_32 = Cycle( MAX_VAL32);
+static const Cycle MAX_CYCLE_64 = Cycle( MAX_VAL64);
+
+static const Latency MAX_LATENCY_8  = Latency( MAX_VAL8); 
+static const Latency MAX_LATENCY_16 = Latency( MAX_VAL16);
+static const Latency MAX_LATENCY_32 = Latency( MAX_VAL32);
+static const Latency MAX_LATENCY_64 = Latency( MAX_VAL64);
+
+
 using Cycles = uint64;
 
 #endif // #ifndef COMMON__TYPES_H


### PR DESCRIPTION
I have fixed some problems in the implementation and introduced new types to ports and perf_sim. I have also added a new method to convert `Cycle` to `double` because we need it in perf_sim. Speaking about an implementation in ports, I have turned old-style array into std::map in ports test.