### PR TITLE
Remove is_HI_master_DIV_MULT, use ports instead of direct communication with bu, make improvements

### DIFF
--- a/simulator/bypass/data_bypass.cpp
+++ b/simulator/bypass/data_bypass.cpp
@@ -20,17 +20,8 @@ void DataBypass::trace_new_register( const MIPSInstr& instr, MIPSRegister num)
     if ( instr.is_conditional_move())
         entry.ready_stage = RegisterStage::in_RF();
     else
-        entry.ready_stage = instr.is_load() ? 1_RSG  // MEMORY 
+        entry.ready_stage = instr.is_load() ? 1_RSG  // MEMORY
                                             : 0_RSG; // EXECUTE
-
-    if ( instr.get_dst_num().is_mips_hi_lo())
-    {
-        is_HI_master_DIVMULT = true;
-    }
-    else if ( num.is_mips_lo())
-    {
-        is_HI_master_DIVMULT = false;
-    }
 
     entry.is_bypassible = ( entry.current_stage == entry.ready_stage);
     traced_registers.emplace( num);

--- a/simulator/bypass/data_bypass.cpp
+++ b/simulator/bypass/data_bypass.cpp
@@ -20,7 +20,7 @@ void DataBypass::trace_new_register( const MIPSInstr& instr, MIPSRegister num)
     if ( instr.is_conditional_move())
         entry.ready_stage = RegisterStage::in_RF();
     else
-        entry.ready_stage = instr.is_load() ? 1_RSG  // MEMORY 
+        entry.ready_stage = instr.is_load() ? 1_RSG  // MEMORY
                                             : 0_RSG; // EXECUTE
 
     entry.is_bypassible = ( entry.current_stage == entry.ready_stage);

--- a/simulator/bypass/data_bypass.cpp
+++ b/simulator/bypass/data_bypass.cpp
@@ -20,7 +20,7 @@ void DataBypass::trace_new_register( const MIPSInstr& instr, MIPSRegister num)
     if ( instr.is_conditional_move())
         entry.ready_stage = RegisterStage::in_RF();
     else
-        entry.ready_stage = instr.is_load() ? 1_RSG  // MEMORY
+        entry.ready_stage = instr.is_load() ? 1_RSG  // MEMORY 
                                             : 0_RSG; // EXECUTE
 
     entry.is_bypassible = ( entry.current_stage == entry.ready_stage);
@@ -70,7 +70,7 @@ void DataBypass::update()
 }
 
 
-void DataBypass::cancel( const MIPSInstr& instr)
+void DataBypass::untrace_instr( const MIPSInstr& instr)
 {
     auto dst_reg_num = instr.get_dst_num();
 

--- a/simulator/bypass/data_bypass.h
+++ b/simulator/bypass/data_bypass.h
@@ -179,7 +179,7 @@ class DataBypass
         // updates the scoreboard
         void update();
 
-        // removes the information about passed instruction from scoreboard
+        // removes the information about passed instruction from the scoreboard
         void untrace_instr( const MIPSInstr& instr);
 };
 

--- a/simulator/bypass/data_bypass.h
+++ b/simulator/bypass/data_bypass.h
@@ -179,8 +179,8 @@ class DataBypass
         // updates the scoreboard
         void update();
 
-        // discards the information about passed instruction
-        void cancel( const MIPSInstr& instr);
+        // removes the information about passed instruction from scoreboard
+        void untrace_instr( const MIPSInstr& instr);
 };
 
 

--- a/simulator/bypass/data_bypass.h
+++ b/simulator/bypass/data_bypass.h
@@ -147,19 +147,6 @@ class DataBypass
             return static_cast<uint8>( bypassing_stage);
         }
 
-        // transforms bypassing data if needed in accordance with destination register
-        static auto get_bypassing_data( const MIPSInstr& instr)
-        {
-            const auto register_num = instr.get_dst_num();
-            
-            auto bypassing_data = instr.get_v_dst();
-
-            if ( register_num.is_mips_hi())
-                bypassing_data <<= 32;
-            
-            return bypassing_data;
-        }
-
         // transforms bypassed data if needed in accordance with passed bypass command
         static auto adapt_bypassed_data( const BypassCommand& bypass_command, uint64 bypassed_data)
         {

--- a/simulator/bypass/data_bypass.h
+++ b/simulator/bypass/data_bypass.h
@@ -23,11 +23,11 @@ class DataBypass
                 explicit RegisterStage( uint8 value) : value( value) { }
 
                 auto operator==( const RegisterStage& rhs) const { return value == rhs.value; }
-                explicit operator std::size_t() const { return static_cast<std::size_t>( value); }
+                explicit operator uint8() const { return value; }
 
                 void inc() { ++value; }
 
-                static constexpr std::size_t get_bypassing_stages_number() { return LAST_BYPASSING_STAGE + 1; }
+                static constexpr uint8 get_bypassing_stages_number() { return LAST_BYPASSING_STAGE + 1; }
                 static RegisterStage get_last_bypassing_stage() { return RegisterStage( LAST_BYPASSING_STAGE); }
                 static RegisterStage in_RF() { return RegisterStage( IN_RF_STAGE_VALUE); }
 
@@ -115,16 +115,16 @@ class DataBypass
 
     public:
         // checks whether the source register of passed instruction is in RF  
-        auto is_in_RF( const MIPSInstr& instr, std::size_t src_index) const
+        auto is_in_RF( const MIPSInstr& instr, uint8 src_index) const
         {
-            const auto reg_num = ( src_index == 0) ? instr.get_src1_num() : instr.get_src2_num();
+            const auto reg_num = instr.get_src_num( src_index);
             return scoreboard.get_entry( reg_num).current_stage == RegisterStage::in_RF();
         }
 
         // checks whether the source register of passed instruction is bypassible
-        auto is_bypassible( const MIPSInstr& instr, std::size_t src_index) const
+        auto is_bypassible( const MIPSInstr& instr, uint8 src_index) const
         {
-            const auto reg_num = ( src_index == 0) ? instr.get_src1_num() : instr.get_src2_num();
+            const auto reg_num = instr.get_src_num( src_index);
             return scoreboard.get_entry( reg_num).is_bypassible;
         }
 
@@ -137,9 +137,9 @@ class DataBypass
 
         // returns bypass command for passed instruction and its source register
         // in accordance with current state of the scoreboard
-        auto get_bypass_command( const MIPSInstr& instr, std::size_t src_index) const
+        auto get_bypass_command( const MIPSInstr& instr, uint8 src_index) const
         {
-            const auto reg_num = ( src_index == 0) ? instr.get_src1_num() : instr.get_src2_num();
+            const auto reg_num = instr.get_src_num( src_index);
             return BypassCommand( get_current_stage( reg_num), reg_num);
         }
 
@@ -148,7 +148,7 @@ class DataBypass
         auto get_bypass_direction( const BypassCommand& bypass_command) const
         {
             const auto bypassing_stage = bypass_command.get_bypassing_stage();
-            return static_cast<std::size_t>( bypassing_stage);
+            return static_cast<uint8>( bypassing_stage);
         }
 
         // transforms bypassed data if needed in accordance with passed bypass command and

--- a/simulator/core/perf_sim.cpp
+++ b/simulator/core/perf_sim.cpp
@@ -270,7 +270,7 @@ void PerfSim<ISA>::clock_execute( Cycle cycle)
             }
 
             /* transform received data in accordance with bypass command */
-            const auto adapted_data = bypassing_unit->adapt_bypassed_data( bypass_command, data);
+            const auto adapted_data = DataBypass::adapt_bypassed_data( bypass_command, data);
 
             instr.set_v_src( adapted_data, src_index);
         }
@@ -287,7 +287,7 @@ void PerfSim<ISA>::clock_execute( Cycle cycle)
     instr.execute();
     
     /* bypass data */
-    wp_execute_2_execute_bypass->write( instr.get_v_dst(), cycle);
+    wp_execute_2_execute_bypass->write( DataBypass::get_bypassing_data( instr), cycle);
 
     wp_execute_2_memory->write( instr, cycle);
 
@@ -345,7 +345,7 @@ void PerfSim<ISA>::clock_memory( Cycle cycle)
     memory->load_store( &instr);
     
     /* bypass data */
-    wp_memory_2_execute_bypass->write( instr.get_v_dst(), cycle);
+    wp_memory_2_execute_bypass->write( DataBypass::get_bypassing_data( instr), cycle);
 
     wp_memory_2_writeback->write( instr, cycle);
 

--- a/simulator/core/perf_sim.cpp
+++ b/simulator/core/perf_sim.cpp
@@ -179,7 +179,7 @@ void PerfSim<ISA>::clock_decode( Cycle cycle)
         return;   
     }
 
-    for ( std::size_t src_index = 0; src_index < SRC_REGISTERS_NUM; src_index++)
+    for ( uint8 src_index = 0; src_index < SRC_REGISTERS_NUM; src_index++)
     {
         if ( bypassing_unit->is_in_RF( instr, src_index))
         {
@@ -251,13 +251,7 @@ void PerfSim<ISA>::clock_execute( Cycle cycle)
     auto instr = rp_decode_2_execute->read( cycle);
 
 
-    void (MIPSInstr::*setters_v_sources[SRC_REGISTERS_NUM])( uint32) = 
-    {
-        &MIPSInstr::set_v_src1,
-        &MIPSInstr::set_v_src2
-    };
-
-    for ( std::size_t src_index = 0; src_index < SRC_REGISTERS_NUM; src_index++)
+    for ( uint8 src_index = 0; src_index < SRC_REGISTERS_NUM; src_index++)
     {   
         /* check whether bypassing is needed for a source register */ 
         if ( rps_decode_2_execute_command[src_index]->is_ready( cycle))
@@ -269,7 +263,7 @@ void PerfSim<ISA>::clock_execute( Cycle cycle)
             const auto data = rps_stages_2_execute_sources_bypass[src_index][bypass_direction]->read( cycle);
 
             /* ignoring all other ports for a source register */
-            for ( std::size_t i = 0; i < DataBypass::RegisterStage::get_bypassing_stages_number(); i++)
+            for ( uint8 i = 0; i < DataBypass::RegisterStage::get_bypassing_stages_number(); i++)
             {    
                 if ( i != bypass_direction)
                     rps_stages_2_execute_sources_bypass[src_index][i]->ignore( cycle);
@@ -278,13 +272,13 @@ void PerfSim<ISA>::clock_execute( Cycle cycle)
             /* transform received data in accordance with bypass command */
             const auto adapted_data = bypassing_unit->adapt_bypassed_data( bypass_command, data);
 
-            (instr.*setters_v_sources[src_index])( adapted_data);
+            instr.set_v_src( adapted_data, src_index);
         }
         else
         {
             /* ignoring all bypassed data for a source register */
             for ( auto& port:rps_stages_2_execute_sources_bypass[src_index])
-                port->ignore( cycle);    
+                port->ignore( cycle);
         }
     }
     

--- a/simulator/core/perf_sim.cpp
+++ b/simulator/core/perf_sim.cpp
@@ -305,7 +305,7 @@ void PerfSim<ISA>::clock_execute( Cycle cycle)
     instr.execute();
     
     /* bypass data */
-    wp_execute_2_execute_bypass->write( DataBypass::get_bypassing_data( instr), cycle);
+    wp_execute_2_execute_bypass->write( instr.get_bypassing_data(), cycle);
 
     wp_execute_2_memory->write( instr, cycle);
 
@@ -366,7 +366,7 @@ void PerfSim<ISA>::clock_memory( Cycle cycle)
     memory->load_store( &instr);
     
     /* bypass data */
-    wp_memory_2_execute_bypass->write( DataBypass::get_bypassing_data( instr), cycle);
+    wp_memory_2_execute_bypass->write( instr.get_bypassing_data(), cycle);
 
     wp_memory_2_writeback->write( instr, cycle);
 

--- a/simulator/core/perf_sim.h
+++ b/simulator/core/perf_sim.h
@@ -71,7 +71,8 @@ private:
 
     static constexpr const uint8 SRC_REGISTERS_NUM = 2;
     static constexpr const uint8 BYPASSING_STAGES_NUM = DataBypass::RegisterStage::get_bypassing_stages_number();
-    
+    static constexpr const uint8 BYPASSING_UNIT_FLUSH_NOTIFIERS_NUM = 2;
+
     std::array<std::array<std::unique_ptr<ReadPort<uint64>>, BYPASSING_STAGES_NUM>, SRC_REGISTERS_NUM> 
         rps_stages_2_execute_sources_bypass;
 
@@ -80,6 +81,12 @@ private:
 
     std::unique_ptr<WritePort<Instr>> wp_decode_2_bypassing_unit = nullptr;
     std::unique_ptr<ReadPort<Instr>> rp_decode_2_bypassing_unit = nullptr;
+
+    std::unique_ptr<WritePort<Instr>> wp_execute_2_bypassing_unit_flush = nullptr;
+    std::unique_ptr<WritePort<Instr>> wp_memory_2_bypassing_unit_flush = nullptr;
+    
+    std::array<std::unique_ptr<ReadPort<Instr>>, BYPASSING_UNIT_FLUSH_NOTIFIERS_NUM> 
+        rps_stages_2_bypassing_unit_flush;
 
     /* main stages functions */
     void clock_decode( Cycle cycle);

--- a/simulator/core/perf_sim.h
+++ b/simulator/core/perf_sim.h
@@ -69,8 +69,8 @@ private:
     std::unique_ptr<WritePort<uint64>> wp_execute_2_execute_bypass = nullptr;
     std::unique_ptr<WritePort<uint64>> wp_memory_2_execute_bypass = nullptr;
 
-    static constexpr const std::size_t SRC_REGISTERS_NUM = 2;
-    static constexpr const std::size_t BYPASSING_STAGES_NUM = DataBypass::RegisterStage::get_bypassing_stages_number();
+    static constexpr const uint8 SRC_REGISTERS_NUM = 2;
+    static constexpr const uint8 BYPASSING_STAGES_NUM = DataBypass::RegisterStage::get_bypassing_stages_number();
     
     std::array<std::array<std::unique_ptr<ReadPort<uint64>>, BYPASSING_STAGES_NUM>, SRC_REGISTERS_NUM> 
         rps_stages_2_execute_sources_bypass;

--- a/simulator/func_sim/rf.h
+++ b/simulator/func_sim/rf.h
@@ -46,12 +46,9 @@ public:
 public:
     RF() = default;
 
-    inline void read_source( FuncInstr* instr, std::size_t src_index) const
+    inline void read_source( FuncInstr* instr, uint8 index) const
     {
-        if ( src_index == 0)
-            instr->set_v_src1( read( instr->get_src1_num()));
-        else
-            instr->set_v_src2( read( instr->get_src2_num()));
+        instr->set_v_src( read( instr->get_src_num( index)), index);
     }
 
     inline void read_sources( FuncInstr* instr) const

--- a/simulator/mips/mips_instr.h
+++ b/simulator/mips/mips_instr.h
@@ -296,8 +296,7 @@ class MIPSInstr
             return PC == rhs.PC && instr.raw == rhs.instr.raw;
         }
 
-        MIPSRegister get_src1_num() const { return src1; }
-        MIPSRegister get_src2_num() const { return src2; }
+        MIPSRegister get_src_num( uint8 index) const { return ( index == 0) ? src1 : src2; }
         MIPSRegister get_dst_num()  const { return dst;  }
 
         /* Checks if instruction can change PC in unusual way. */
@@ -329,8 +328,13 @@ class MIPSInstr
 
         bool is_bubble() const { return is_nop() && PC == 0; }
 
-        void set_v_src1(uint32 value) { v_src1 = value; }
-        void set_v_src2(uint32 value) { v_src2 = value; }
+        void set_v_src( uint32 value, uint8 index)
+        {
+            if ( index == 0)
+                v_src1 = value;
+            else
+                v_src2 = value;
+        }
 
         uint64 get_v_dst() const { return v_dst; }
 

--- a/simulator/mips/mips_instr.h
+++ b/simulator/mips/mips_instr.h
@@ -346,6 +346,11 @@ class MIPSInstr
         void set_v_dst(uint32 value); // for loads
         uint32 get_v_src2() const { return v_src2; } // for stores
 
+        uint64 get_bypassing_data() const
+        {
+            return ( dst.is_mips_hi()) ? v_dst << 32 : v_dst; 
+        }
+
         void execute();
         void check_trap();
 };

--- a/simulator/writeback/writeback.cpp
+++ b/simulator/writeback/writeback.cpp
@@ -1,3 +1,6 @@
+
+#include <bypass/data_bypass.h>
+
 #include <cassert>
 
 #include <iostream>
@@ -43,7 +46,7 @@ void Writeback<ISA>::clock( Cycle cycle)
     instr.check_trap();
 
     /* bypass data */
-    wp_bypass->write( instr.get_v_dst(), cycle);
+    wp_bypass->write( DataBypass::get_bypassing_data( instr), cycle);
 
     /* log */
     sout << instr << std::endl;

--- a/simulator/writeback/writeback.cpp
+++ b/simulator/writeback/writeback.cpp
@@ -1,6 +1,3 @@
-
-#include <bypass/data_bypass.h>
-
 #include <cassert>
 
 #include <iostream>
@@ -46,7 +43,7 @@ void Writeback<ISA>::clock( Cycle cycle)
     instr.check_trap();
 
     /* bypass data */
-    wp_bypass->write( DataBypass::get_bypassing_data( instr), cycle);
+    wp_bypass->write( instr.get_bypassing_data(), cycle);
 
     /* log */
     sout << instr << std::endl;

--- a/simulator/writeback/writeback.h
+++ b/simulator/writeback/writeback.h
@@ -26,7 +26,7 @@ private:
     /* Simulator internals */
     RF<ISA>* rf = nullptr;
 
-    static constexpr const std::size_t SRC_REGISTERS_NUM = 2;
+    static constexpr const uint8 SRC_REGISTERS_NUM = 2;
 
     /* Input */
     std::unique_ptr<ReadPort<Instr>> rp_datapath = nullptr;


### PR DESCRIPTION
There is a list of improvements:
1) is_HI_master_DIV_MULT flag was removed and a new static method of DataBypass class called `get_bypassing_data` was introduced in order to cut through the HI/LO problem
2) stages_2_bypassing_unit_flush ports were implemented to notify bypassing unit about invalid instructions in flushed stages
3)  some other improvements were made

    Moreover, my idea to use std::set for traced registers was extremely bad. At least std::unordered_set should have been used, however, total efficiency of that part of code is still questionable so I would like to postpone removing it.
     DataBypass class still should be generalized by me.