### PR TITLE
Be more careful with shifting signed values

### DIFF
--- a/simulator/func_sim/rf/rf.h
+++ b/simulator/func_sim/rf/rf.h
@@ -38,7 +38,7 @@ class RF
         // on `if constexpr ()` with template
         // LLVM bug 35824: https://bugs.llvm.org/show_bug.cgi?id=35824
         if constexpr( HAS_WIDE_DST)
-            return value >> 32; // NOLINT
+            return value >> 32u; // NOLINT(misc-suspicious-semicolon)
 
         // GCC bug 81676 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81676
         // Wrong warning with unused-but-set-parameter within 'if constexpr'
@@ -57,8 +57,8 @@ protected:
     std::enable_if_t<HAS_WIDE_DST, U> read_hi_lo() const
     {
         const auto hi = static_cast<RegDstUInt>( read( Register::mips_hi));
-        const auto lo = static_cast<RegDstUInt>( read( Register::mips_lo)) & ((RegDstUInt(1) << 32) - 1);
-        return (hi << 32) | lo;
+        const auto lo = static_cast<RegDstUInt>( read( Register::mips_lo)) & ((RegDstUInt(1) << 32u) - 1);
+        return (hi << 32u) | lo;
     }
 
     // Makes no sense if output is 32 bit

--- a/simulator/mips/mips_instr.cpp
+++ b/simulator/mips/mips_instr.cpp
@@ -460,7 +460,7 @@ void MIPSInstr::execute()
         std::ostringstream oss;
         oss << "\t [ $" << std::hex;
         if ( dst.is_mips_hi_lo())
-            oss <<  MIPSRegister::mips_hi << " = 0x" << static_cast<uint32>( v_dst >> 32) << ", $"
+            oss <<  MIPSRegister::mips_hi << " = 0x" << static_cast<uint32>( v_dst >> 32u) << ", $"
                 <<  MIPSRegister::mips_lo;
         else
             oss <<  dst;

--- a/simulator/mips/mips_instr.h
+++ b/simulator/mips/mips_instr.h
@@ -20,8 +20,8 @@
 
 #include "mips_register/mips_register.h"
 
-inline int32 sign_extend(int16 v)  { return static_cast<int32>(v); }
-inline int32 zero_extend(uint16 v) { return static_cast<int32>(v); }
+inline int32  sign_extend(int16 v)  { return static_cast<int32>(v); }
+inline uint32 zero_extend(uint16 v) { return static_cast<uint32>(v); }
 
 inline uint32 count_zeros(uint32 value)
 {
@@ -50,7 +50,7 @@ uint64 mips_division(T x, T y) {
         return 0;
     auto x1 = static_cast<T64>(x);
     auto y1 = static_cast<T64>(y);
-    return static_cast<uint64>(static_cast<uint32>(x1 / y1)) | (static_cast<uint64>(static_cast<uint32>(x1 % y1)) << 32);
+    return static_cast<uint64>(static_cast<uint32>(x1 / y1)) | (static_cast<uint64>(static_cast<uint32>(x1 % y1)) << 32u);
 }
 
 class MIPSInstr
@@ -221,11 +221,11 @@ class MIPSInstr
 
         void execute_sll()   { v_dst = v_src1 << shamt; }
         void execute_srl()   { v_dst = v_src1 >> shamt; }
-        void execute_sra()   { v_dst = static_cast<int32>( v_src1) >> shamt; }
+        void execute_sra()   { v_dst = static_cast<int32>( v_src1) >> shamt; } // NOLINT(hicpp-signed-bitwise) Implementation defined actually
         void execute_sllv()  { v_dst = v_src1 << v_src2; }
         void execute_srlv()  { v_dst = v_src1 >> v_src2; }
-        void execute_srav()  { v_dst = static_cast<int32>( v_src1) >> v_src2; }
-        void execute_lui()   { v_dst = sign_extend( v_imm) << 0x10; }
+        void execute_srav()  { v_dst = static_cast<int32>( v_src1) >> v_src2; } // NOLINT(hicpp-signed-bitwise) Implementation defined actually
+        void execute_lui()   { v_dst = static_cast<uint32>( sign_extend( v_imm)) << 0x10u; }
 
         void execute_and()   { v_dst = v_src1 & v_src2; }
         void execute_or()    { v_dst = v_src1 | v_src2; }
@@ -251,7 +251,7 @@ class MIPSInstr
         {
             _is_jump_taken = (this->*p)();
             if ( _is_jump_taken)
-                new_PC += sign_extend( v_imm) << 2;
+                new_PC += sign_extend( v_imm) * 4;
         }
 
         void execute_clo() { v_dst = count_zeros( ~v_src1); }
@@ -263,9 +263,9 @@ class MIPSInstr
             new_PC = target;
         }
 
-        void execute_j()  { execute_jump((PC & 0xf0000000) | (v_imm << 2)); }
+        void execute_j()  { execute_jump((PC & 0xf0000000) | (v_imm << 2u)); }
         void execute_jr() { execute_jump(align_up<2>(v_src1)); }
-        void execute_jal()  { v_dst = new_PC; execute_jump((PC & 0xf0000000) | (v_imm << 2)); }
+        void execute_jal()  { v_dst = new_PC; execute_jump((PC & 0xf0000000) | (v_imm << 2u)); }
         void execute_jalr() { v_dst = new_PC; execute_jump(align_up<2>(v_src1)); }
 
         template<Predicate p>
@@ -275,7 +275,7 @@ class MIPSInstr
             if ( _is_jump_taken)
             {
                 v_dst = new_PC;
-                new_PC += sign_extend( v_imm) << 2;
+                new_PC += sign_extend( v_imm) * 4;
             }
         }
 
@@ -355,7 +355,7 @@ class MIPSInstr
 
         uint64 get_bypassing_data() const
         {
-            return ( dst.is_mips_hi()) ? v_dst << 32 : v_dst;
+            return ( dst.is_mips_hi()) ? v_dst << 32u : v_dst;
         }
 
         void execute();


### PR DESCRIPTION
According to C++ standard, shifting of signed values and/or by signed values is implementation defined.
For instructions like `sra` and `srav` we should invent something.