### PR TITLE
Prevent bypassing from MTHI instruction

### DIFF
--- a/simulator/mips/mips_instr.h
+++ b/simulator/mips/mips_instr.h
@@ -389,6 +389,8 @@ class MIPSInstr
 
         bool is_special() const { return operation == OUT_R_SPECIAL; }
 
+        bool is_mthi() const { return operation == OUT_R_MTHI; }
+
         bool has_trap() const { return trap != TrapType::NO_TRAP; }
 
         bool is_bubble() const { return is_nop() && PC == 0; }
@@ -411,11 +413,6 @@ class MIPSInstr
 
         void set_v_dst(uint32 value); // for loads
         uint32 get_v_src2() const { return v_src2; } // for stores
-
-        uint64 get_bypassing_data() const
-        {
-            return ( dst.is_mips_hi()) ? v_dst << 32u : v_dst;
-        }
 
         void execute();
         void check_trap();

--- a/simulator/modules/core/perf_instr.h
+++ b/simulator/modules/core/perf_instr.h
@@ -23,6 +23,7 @@ public:
 
     bool is_bypassible() const { return !this->is_conditional_move() &&
                                         !this->is_partial_load()     &&
+                                        !this->is_mthi()             &&
                                         this->get_accumulation_type() == 0; }
 
     auto is_complex_arithmetic() const { return this->is_divmult(); }

--- a/simulator/modules/execute/execute.cpp
+++ b/simulator/modules/execute/execute.cpp
@@ -103,7 +103,7 @@ void Execute<ISA>::clock( Cycle cycle)
 
         if ( has_flush_expired())
         {
-            wp_complex_arithmetic_bypass->write( instr.get_bypassing_data(), cycle);
+            wp_complex_arithmetic_bypass->write( instr.get_v_dst(), cycle);
             wp_writeback_datapath->write( instr, cycle);
         }
     }
@@ -123,9 +123,7 @@ void Execute<ISA>::clock( Cycle cycle)
         return;
     }
 
-
     auto instr = rp_datapath->read( cycle);
-
 
     for ( uint8 src_index = 0; src_index < SRC_REGISTERS_NUM; src_index++)
     {   
@@ -170,7 +168,7 @@ void Execute<ISA>::clock( Cycle cycle)
     else
     {
         /* bypass data */
-        wp_bypass->write( instr.get_bypassing_data(), cycle);
+        wp_bypass->write( instr.get_v_dst(), cycle);
         
         if ( instr.is_mem_stage_required())
             wp_mem_datapath->write( instr, cycle);

--- a/simulator/modules/mem/mem.cpp
+++ b/simulator/modules/mem/mem.cpp
@@ -77,7 +77,7 @@ void Mem<ISA>::clock( Cycle cycle)
     memory->load_store( &instr);
     
     /* bypass data */
-    wp_bypass->write( instr.get_bypassing_data(), cycle);
+    wp_bypass->write( instr.get_v_dst(), cycle);
 
     wp_datapath->write( instr, cycle);
 

--- a/simulator/modules/writeback/writeback.cpp
+++ b/simulator/modules/writeback/writeback.cpp
@@ -45,7 +45,7 @@ void Writeback<ISA>::clock( Cycle cycle)
     instr.check_trap();
 
     /* bypass data */
-    wp_bypass->write( instr.get_bypassing_data(), cycle);
+    wp_bypass->write( instr.get_v_dst(), cycle);
 
     /* log */
     sout << instr << std::endl;

--- a/simulator/risc_v/riscv_instr.h
+++ b/simulator/risc_v/riscv_instr.h
@@ -96,6 +96,8 @@ class RISCVInstr
 
         constexpr bool is_partial_store() const { return false; }
 
+        constexpr bool is_mthi() const { return false; }
+
         void set_v_src( const T& value, uint8 index)
         {
             if ( index == 0)


### PR DESCRIPTION
MTHI is a very rare MIPS instruction, but in the moment it requires a
lot of gimnastics to get it working with data bypasses. Let's postpone
its implementation until 2-dst source is ready