### PR TITLE
Remove GNU binutils out of the repository.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,10 @@ before_build:
 - set PATH=%LIBELF_INCLUDE%;%PATH%
 - set INCLUDE=%BOOST_ROOT%;%INCLUDE%
 # build binutils
-- set BINUTILS=/c/projects/mipt-mips/binutils
+- set BINUTILS_VER=binutils-2.31
+- bash -lc "cd /c/projects/mipt-mips; wget http://ftp.gnu.org/gnu/binutils/$BINUTILS_VER.tar.bz2"
+- bash -lc "cd /c/projects/mipt-mips; tar xjf $BINUTILS_VER.tar.bz2"
+- set BINUTILS=/c/projects/mipt-mips/%BINUTILS_VER%
 - bash -lc "cd %BINUTILS%; ./configure --target=mips-linux-gnu --prefix=%BINUTILS%/cross/mips --disable-gdb --disable-gprof > /dev/null"
 - bash -lc "cd %BINUTILS%; sed -i 's/-O2/-O0/g' Makefile" # disable optimizations to speed up build a little
 - bash -lc "cd %BINUTILS%; make all install MAKEINFO=true > /dev/null"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "binutils"]
-	path = binutils
-	url = https://github.com/bminor/binutils-gdb.git
 [submodule "traces"]
 	path = traces
 	url = https://github.com/MIPT-ILab/mips-traces.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,18 +46,20 @@ install:
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
         brew install libelf zlib
     fi
-# Build binutils on OS X
+# Download and build binutils on OS X
   - |
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        export BINUTILS_VER=binutils-2.31
         cd $TRAVIS_BUILD_DIR
-        git submodule update --init binutils
-        cd binutils
-        BINUTILS=$TRAVIS_BUILD_DIR/binutils/cross/mips
+        wget http://ftp.gnu.org/gnu/binutils/$BINUTILS_VER.tar.bz2
+        tar xjf $BINUTILS_VER.tar.bz2
+        cd $BINUTILS_VER
+        BINUTILS=$TRAVIS_BUILD_DIR/binutils-2.31/cross/mips
         ./configure --target=mips-linux-gnu --prefix=$BINUTILS --disable-gdb --disable-gprof --with-system-zlib > /dev/null
         make all install MAKEINFO=true > /dev/null
         export PATH=$PATH:$BINUTILS/bin
     fi
-# Build binutils on Linux
+# Download binutils on Linux
   - |
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
         sudo apt-get install binutils-mips-linux-gnu --allow-unauthenticated


### PR DESCRIPTION
Actually these sources are needed once or not needed at all,
so there is no need to keep them in the repository. Additionally,
submodules confuse newcomers who do not have much experience with git.