### PR TITLE
Ignore unused data in ports automatically

### DIFF
--- a/simulator/infra/ports/ports.cpp
+++ b/simulator/infra/ports/ports.cpp
@@ -14,10 +14,10 @@ void init_ports()
         map->init();
 }
 
-void check_ports( Cycle cycle)
+void clean_up_ports( Cycle cycle)
 {
     for ( auto map : BasePort::BaseMap::all_maps)
-        map->check( cycle);
+        map->clean_up( cycle);
 }
 
 void destroy_ports()

--- a/simulator/infra/ports/ports.h
+++ b/simulator/infra/ports/ports.h
@@ -29,29 +29,29 @@ template<class T> class WritePort;
 
 // Global port handlers
 extern void init_ports();
-extern void check_ports( Cycle cycle);
+extern void clean_up_ports( Cycle cycle);
 extern void destroy_ports();
 
 class BasePort : protected Log
 {
         friend void init_ports();
-        friend void check_ports( Cycle cycle);
+        friend void clean_up_ports( Cycle cycle);
         friend void destroy_ports();
 
     protected:
         class BaseMap : public Log
         {
                 friend void init_ports();
-                friend void check_ports( Cycle cycle);
+                friend void clean_up_ports( Cycle cycle);
                 friend void destroy_ports();
 
                 virtual void init() const = 0;
-                virtual void check( Cycle cycle) const = 0;
+                virtual void clean_up( Cycle cycle) = 0;
                 virtual void destroy() = 0;
 
                 static std::list<BaseMap*> all_maps;
             protected:
-                BaseMap() : Log(true) { all_maps.push_back( this); }
+                BaseMap() : Log( false) { all_maps.push_back( this); }
         };
 
         // Key of port
@@ -61,7 +61,7 @@ class BasePort : protected Log
         bool _init = false;
 
         // Constructor of port
-        explicit BasePort( std::string key) : Log( true), _key( std::move( key)) { }
+        explicit BasePort( std::string key) : Log( false), _key( std::move( key)) { }
 };
 
 /*
@@ -92,7 +92,7 @@ template<class T> class Port : public BasePort
             void init() const final;
 
             // Finding lost elements
-            void check( Cycle cycle) const final;
+            void clean_up( Cycle cycle) final;
 
             // Destroy connections
             void destroy() final;
@@ -142,9 +142,9 @@ template<class T> class WritePort : public Port<T>
 
         void init( const ReadListType& readers);
 
-        void check( Cycle cycle) const {
+        void clean_up( Cycle cycle) {
             for ( const auto& reader : _destinations)
-                reader->check( cycle);
+                reader->clean_up( cycle);
         }
 
         // destroy all ports
@@ -183,6 +183,7 @@ template<class T> class ReadPort: public Port<T>
 {
         friend class WritePort<T>;
     private:
+        using Log::sout;
         using Log::serr;
         using Log::critical;
 
@@ -206,7 +207,7 @@ template<class T> class ReadPort: public Port<T>
         }
 
         // Tests if there is any ungot data
-        void check( Cycle cycle) const;
+        void clean_up( Cycle cycle);
     public:
         /*
          * Constructor
@@ -227,9 +228,6 @@ template<class T> class ReadPort: public Port<T>
 
         // Read method
         T read( Cycle cycle);
-
-        // Read but ignore the data
-        void ignore( Cycle cycle);
 };
 
 /*
@@ -361,25 +359,16 @@ template<class T> T ReadPort<T>::read( Cycle cycle)
 }
 
 /*
- * Ignoring read method
- *
- * Reads all data which should be read in this cycle but does not copy it
- */
-template<class T> void ReadPort<T>::ignore( Cycle cycle)
-{
-    while ( this->is_ready( cycle))
-         _dataQueue.pop();
-}
-
-/*
  * Tests if there is any data that can not be used ever.
 */
-template<class T> void ReadPort<T>::check( Cycle cycle) const
+template<class T> void ReadPort<T>::clean_up( Cycle cycle)
 {
-    if ( !_dataQueue.empty() && _dataQueue.front().cycle < cycle)
-        serr << "In " << this->_key << " port data was added at "
+    while ( !_dataQueue.empty() && _dataQueue.front().cycle < cycle) {
+        sout << "In " << this->_key << " port data was added at "
              << (_dataQueue.front().cycle - _latency)
-             << " clock and will not be readed" << std::endl << critical;
+             << " clock and was not readed\n";
+        _dataQueue.pop();
+    }
 }
 
 /*
@@ -419,10 +408,10 @@ template<class T> void Port<T>::Map::destroy()
  * Argument is the number of current cycle.
  * If some token couldn't be get in future, warnings
 */
-template<class T> void Port<T>::Map::check( Cycle cycle) const
+template<class T> void Port<T>::Map::clean_up( Cycle cycle)
 {
     for ( const auto& cluster : _map)
-        cluster.second.writer->check( cycle);
+        cluster.second.writer->clean_up( cycle);
 }
 
 // External methods

--- a/simulator/infra/ports/t/unit_test.cpp
+++ b/simulator/infra/ports/t/unit_test.cpp
@@ -141,7 +141,7 @@ TEST_CASE( "test_ports: Test_Ports_A_B")
         a.clock( cycle);
         b.clock( cycle);
 
-        check_ports( cycle);;
+        clean_up_ports( cycle);;
     }
 
     destroy_ports();;

--- a/simulator/modules/core/perf_sim.cpp
+++ b/simulator/modules/core/perf_sim.cpp
@@ -57,7 +57,7 @@ void PerfSim<ISA>::run( const std::string& tr, uint64 instrs_to_run)
         mem.clock( curr_cycle);
         curr_cycle.inc();
 
-        check_ports( curr_cycle);
+        clean_up_ports( curr_cycle);
     }
 
     auto t_end = std::chrono::high_resolution_clock::now();

--- a/simulator/modules/decode/decode.cpp
+++ b/simulator/modules/decode/decode.cpp
@@ -43,10 +43,8 @@ template <typename ISA>
 typename Decode<ISA>::Instr Decode<ISA>::read_instr( Cycle cycle)
 {
     if ( rp_stall_datapath->is_ready( cycle))
-    {
-        rp_datapath->ignore( cycle);
         return rp_stall_datapath->read( cycle);
-    }
+
     return rp_datapath->read( cycle);
 }
 
@@ -71,21 +69,15 @@ void Decode<ISA>::clock( Cycle cycle)
 
     /* update bypassing unit because of misprediction */
     if ( rp_bypassing_unit_flush_notify->is_ready( cycle))
-    {
-        rp_bypassing_unit_flush_notify->ignore( cycle);
         bypassing_unit->handle_flush();
-    }
 
     /* branch misprediction */
     if ( is_flush)
     {
-        /* ignoring the upcoming instruction as it is invalid */
-        rp_datapath->ignore( cycle);
-        rp_stall_datapath->ignore( cycle);
-
         sout << "flush\n";
         return;
     }
+
     /* check if there is something to process */
     if ( !rp_datapath->is_ready( cycle) && !rp_stall_datapath->is_ready( cycle))
     {

--- a/simulator/modules/fetch/fetch.cpp
+++ b/simulator/modules/fetch/fetch.cpp
@@ -83,8 +83,6 @@ void Fetch<ISA>::clock_bp( Cycle cycle)
 template <typename ISA>
 void Fetch<ISA>::clock_instr_cache( Cycle cycle)
 {
-    ignore( cycle);
-
     if( rp_long_latency_pc_holder->is_ready( cycle))
     {
         /* get PC from long-latency port if it's possible */
@@ -101,18 +99,6 @@ void Fetch<ISA>::clock_instr_cache( Cycle cycle)
 }
 
 template <typename ISA>
-void Fetch<ISA>::ignore( Cycle cycle)
-{
-    /* ignore PC from other ports in the case of cache miss */
-    rp_external_target->ignore( cycle);
-    rp_hold_pc->ignore( cycle);
-    rp_target->ignore( cycle);
-    rp_stall->ignore( cycle);
-    /* ignore miss signal */
-    rp_hit_or_miss->ignore( cycle);
-}
-
-template <typename ISA>
 void Fetch<ISA>::save_flush( Cycle cycle)
 {
     /* save PC in the case of flush signal */
@@ -121,8 +107,6 @@ void Fetch<ISA>::save_flush( Cycle cycle)
     else if( rp_target->is_ready( cycle))
         wp_target->write( rp_target->read( cycle), cycle);
 }
-
-
 
 template <typename ISA>
 Addr Fetch<ISA>::get_cached_PC( Cycle cycle)

--- a/simulator/modules/fetch/fetch.h
+++ b/simulator/modules/fetch/fetch.h
@@ -50,7 +50,6 @@ private:
     void clock_bp( Cycle cycle);
     void clock_instr_cache( Cycle cycle);
     void save_flush( Cycle cycle);
-    void ignore( Cycle cycle);
 public:
     explicit Fetch( bool log);
     void clock( Cycle cycle);

--- a/simulator/modules/mem/mem.cpp
+++ b/simulator/modules/mem/mem.cpp
@@ -38,9 +38,6 @@ void Mem<ISA>::clock( Cycle cycle)
     /* branch misprediction */
     if ( is_flush)
     {
-        /* ignoring the upcoming instruction as it is invalid */
-        rp_datapath->ignore( cycle);
-
         sout << "flush\n";
         return;
     }


### PR DESCRIPTION
Yes, introduction of 'ignore' method was a mistake: too much time of
developers was wasted to place 'ignore' methods properly for different
cases, and the amount of the cases grows exponentially with each
feature.