### PR TITLE
Try to use std::string instead of COW string

### DIFF
--- a/simulator/mips/mips_instr.h
+++ b/simulator/mips/mips_instr.h
@@ -196,11 +196,8 @@ class BaseMIPSInstr
 
         uint64 sequence_id = NO_VAL64;
 
-#if 0
         std::string disasm = {};
-#else
-        KryuCowString disasm = {};
-#endif
+
         void init( const ISAEntry& entry, MIPSVersion version);
 
         // Predicate helpers - unary


### PR DESCRIPTION
With sequence_id, benefit of COW string becomes much less.