### PR TITLE
Check instructuion cache on read instead of write

### DIFF
--- a/simulator/infra/instrcache/LRUCache.h
+++ b/simulator/infra/instrcache/LRUCache.h
@@ -38,8 +38,7 @@ class LRUCache
 
         void touch( const Key& key)
         {
-            auto lru_it  = lru_hash.find( key);
-            lru_list.splice( lru_list.begin(), lru_list, lru_it->second);
+            lru_list.splice( lru_list.begin(), lru_list, lru_hash.find( key)->second);
         }
 
         void update( const Key& key, const Value& value)
@@ -70,20 +69,13 @@ class LRUCache
         void allocate( const Key& key, const Value& value)
         {
             if ( number_of_elements == CAPACITY)
-            {
-                // Delete least recently used element
-                const auto& lru_elem = lru_list.back();
-                lru_hash.erase( lru_elem);
-                data.erase( lru_elem);
-                lru_list.pop_back();
-            }
-            else {
-                 number_of_elements++;
-            }
+                erase( lru_list.back());
+
             // Add a new element
             data.emplace( key, value);
             auto ptr = lru_list.insert( lru_list.begin(), key);
             lru_hash.emplace( key, ptr);
+            number_of_elements++;
         }
 
         std::unordered_map<Key, Value> data{};

--- a/simulator/infra/instrcache/LRUCache.h
+++ b/simulator/infra/instrcache/LRUCache.h
@@ -36,20 +36,18 @@ class LRUCache
             return std::pair<bool, const Value&>( result != data.end(), result->second);
         }
 
+        void touch( const Key& key)
+        {
+            auto lru_it  = lru_hash.find( key);
+            lru_list.splice( lru_list.begin(), lru_list, lru_it->second);
+        }
+
         void update( const Key& key, const Value& value)
         {
-            auto data_it = data.find( key);
-            auto lru_it  = lru_hash.find( key);
-            assert ( ( data_it == data.end()) == ( lru_it == lru_hash.end()));
-            if ( data_it == data.end())
-            {
+            if ( data.find( key) == data.end())
                 allocate( key, value);
-            }
             else
-            {
-                assert( data_it->second.is_same( value));
-                lru_list.splice( lru_list.begin(), lru_list, lru_it->second);
-            }
+                touch( key);
         }
 
         void erase( const Key& key)
@@ -94,18 +92,6 @@ class LRUCache
         std::unordered_map<Key, typename std::list<Key>::const_iterator> lru_hash{};
 
         std::size_t number_of_elements = 0u;
-};
-
-template <typename Value, size_t CAPACITY>
-class AddressLRUCache : public LRUCache<Addr, Value, CAPACITY>
-{
-public:
-    void range_erase( Addr start_address, size_t size)
-    {
-        Addr end_address = start_address + size;
-        for (Addr i = start_address; i < end_address; ++i)
-            this->erase( i);
-    }
 };
 
 #endif // LRUCACHE_H

--- a/simulator/infra/instrcache/t/unit_test.cpp
+++ b/simulator/infra/instrcache/t/unit_test.cpp
@@ -26,7 +26,7 @@ public:
 
 TEST_CASE( "update_and_find_int: Update_Find_And_Check_Using_Int")
 {
-    AddressLRUCache<Dummy, 8192> cache{};
+    LRUCache<Addr, Dummy, 8192> cache{};
 
     const Addr PC = 0x401c04;
     const Dummy test_number( 0x103abf9);
@@ -40,11 +40,11 @@ TEST_CASE( "update_and_find_int: Update_Find_And_Check_Using_Int")
 
 TEST_CASE( "check_method_size: Check_Method_Size")
 {
-    AddressLRUCache<MIPS32Instr, 8192> instr_cache{};
+    LRUCache<Addr, MIPS32Instr, 8192> instr_cache{};
 
     uint32 instr_bytes = 0x2484ae10;
     Addr PC = 0x30ae17;
-    const std::size_t SIZE = AddressLRUCache<MIPS32Instr, 8192>::get_capacity() / 12;
+    const std::size_t SIZE = LRUCache<Addr, MIPS32Instr, 8192>::get_capacity() / 12;
 
     for ( std::size_t i = 0; i < SIZE; ++i)
     {
@@ -59,7 +59,7 @@ TEST_CASE( "check_method_size: Check_Method_Size")
 
 TEST_CASE( "update_and_find: Update_Find_And_Check")
 {
-    AddressLRUCache<MIPS32Instr, 8192> instr_cache{};
+    LRUCache<Addr, MIPS32Instr, 8192> instr_cache{};
 
     const uint32 instr_bytes = 0x3c010400;
     const Addr PC = 0x401c04;
@@ -71,7 +71,7 @@ TEST_CASE( "update_and_find: Update_Find_And_Check")
 
 TEST_CASE( "check_method_erase: Check_Method_Erase")
 {
-    AddressLRUCache<MIPS32Instr, 8192> instr_cache{};
+    LRUCache<Addr, MIPS32Instr, 8192> instr_cache{};
 
     const uint32 instr_bytes = 0x3c010400;
     const Addr PC = 0x401c04;
@@ -83,31 +83,9 @@ TEST_CASE( "check_method_erase: Check_Method_Erase")
     CHECK( !instr_cache.find( PC).first);
 }
 
-TEST_CASE( "check_method_erase: Check_Method_Range_Erase")
-{
-    AddressLRUCache<MIPS32Instr, 8192> instr_cache{};
-
-    const uint32 instr_bytes = 0x3c010400;
-    const Addr PC = 0x401c04;
-    const MIPS32Instr instr( instr_bytes, PC);
-    const std::size_t SIZE = AddressLRUCache<MIPS32Instr, 8192>::get_capacity() / 12;
-
-    for ( std::size_t i = 0; i < SIZE; ++i)
-    {
-        instr_cache.update( PC + i, instr);
-    }
-    CHECK( SIZE == instr_cache.size());
-    instr_cache.range_erase( PC, 200);
-
-    CHECK( SIZE == instr_cache.size() + 200);
-    CHECK( !instr_cache.find( PC).first);
-    CHECK( !instr_cache.find( PC + 100).first);
-    CHECK( instr_cache.find( PC + 200).first);
-}
-
 TEST_CASE( "check_method_empty: Check_Method_Empty")
 {
-    AddressLRUCache<MIPS32Instr, 8192> instr_cache{};
+    LRUCache<Addr, MIPS32Instr, 8192> instr_cache{};
 
     const uint32 instr_bytes = 0x2484ae10;
     const Addr PC = 0x400d05;

--- a/simulator/mips/mips_instr.h
+++ b/simulator/mips/mips_instr.h
@@ -404,8 +404,12 @@ class BaseMIPSInstr
     public:
         BaseMIPSInstr() = delete;
 
+        bool is_same_bytes( uint32 bytes) const {
+            return instr.raw == bytes;
+        }
+
         bool is_same( const BaseMIPSInstr& rhs) const {
-            return PC == rhs.PC && instr.raw == rhs.instr.raw;
+            return PC == rhs.PC && is_same_bytes( rhs.instr.raw);
         }
         
         bool is_same_checker( const BaseMIPSInstr& rhs) const {

--- a/simulator/risc_v/riscv_instr.h
+++ b/simulator/risc_v/riscv_instr.h
@@ -50,8 +50,12 @@ class RISCVInstr
         explicit
         RISCVInstr( uint32 bytes, Addr PC = 0) : instr( bytes), PC( PC), new_PC( PC + 4) {};
 
+         bool is_same_bytes( uint32 bytes) const {
+            return bytes == instr;
+        }
+        
         bool is_same( const RISCVInstr& rhs) const {
-            return PC == rhs.PC && instr == rhs.instr;
+            return PC == rhs.PC && is_same_bytes( rhs.instr);
         }
 
         bool is_same_checker( const RISCVInstr& /* rhs */) const { return false; }


### PR DESCRIPTION
Current implementation invalidates cache of decoded instruction if
memory cell is rewritten. However, we are going to introduce methods to
overwrite memory externally (GDB and external I/O), and it becomes too
hard to track whether memory is updated. Instead, we will read memory
bytes and cache of decoded instructions and decide whether redecoding is
needed.