### PR TITLE
Move ELF loader to separate translation unit

### DIFF
--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 
 set(CPPS infra/macro_test.cpp
     infra/memory/memory.cpp
+    infra/memory/elf/elf_loader.cpp
     infra/config/config.cpp
     infra/ports/ports.cpp
     infra/cache/cache_tag_array.cpp

--- a/simulator/func_sim/func_sim.cpp
+++ b/simulator/func_sim/func_sim.cpp
@@ -4,6 +4,7 @@
  */
  
 #include "func_sim.h"
+#include <infra/memory/elf/elf_loader.h>
 
 template <typename ISA>
 FuncSim<ISA>::FuncSim( bool log) : Simulator( log), mem( new Memory) { }
@@ -58,7 +59,7 @@ typename FuncSim<ISA>::FuncInstr FuncSim<ISA>::step()
 template <typename ISA>
 void FuncSim<ISA>::init( const std::string& tr)
 {
-    mem->load_elf_file( tr);
+    ::load_elf_file( mem.get(), tr);
     PC = mem->startPC();
     nops_in_a_row = 0;
 }

--- a/simulator/func_sim/t/unit_test.cpp
+++ b/simulator/func_sim/t/unit_test.cpp
@@ -9,6 +9,7 @@
 #include <catch.hpp>
 
 // Module
+#include <infra/memory/elf/elf_loader.h>    
 #include <mips/mips.h>
 
 #include <sstream>

--- a/simulator/infra/memory/elf/elf_loader.cpp
+++ b/simulator/infra/memory/elf/elf_loader.cpp
@@ -1,0 +1,34 @@
+/**
+ * elf-loader.cpp: loader of elf files to guest memory
+ * @author Pavel Kryukov
+ * Copyright 2018 uArchSim iLab project
+ */
+
+#include "elf_loader.h"
+
+#include <elfio/elfio.hpp>
+#include <infra/memory/memory.h>
+
+static void load_elf_section( FuncMemory* memory, const ELFIO::section* section)
+{
+    if ( section->get_address() == 0)
+        return;
+
+    if ( section->get_name() == ".text")
+        memory->set_startPC( section->get_address());
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) Connecting ELFIO to our guidelines
+    memory->memcpy_host_to_guest( section->get_address(), reinterpret_cast<const Byte*>(section->get_data()), section->get_size());
+}
+
+
+void load_elf_file( FuncMemory* memory, const std::string& executable_file_name)
+{
+    ELFIO::elfio reader;
+
+    if ( !reader.load( executable_file_name))
+        throw InvalidElfFile( executable_file_name);
+
+    for ( const auto& section : reader.sections)
+        load_elf_section( memory, section);
+}

--- a/simulator/infra/memory/elf/elf_loader.h
+++ b/simulator/infra/memory/elf/elf_loader.h
@@ -1,0 +1,25 @@
+/**
+ * elf-loader.h: loader of elf files to guest memory
+ * @author Pavel Kryukov
+ * Copyright 2018 uArchSim iLab project
+ */
+ 
+#ifndef ELF_LOADER_H
+#define ELF_LOADER_H
+
+#include <infra/exception.h>
+
+#include <string>
+
+struct InvalidElfFile final : Exception
+{
+    explicit InvalidElfFile(const std::string& name)
+        : Exception("Invalid elf file", name)
+    { }
+};
+
+class FuncMemory;
+
+void load_elf_file(FuncMemory* memory, const std::string& filename);
+
+#endif

--- a/simulator/infra/memory/memory.cpp
+++ b/simulator/infra/memory/memory.cpp
@@ -7,9 +7,6 @@
 
 #include "memory.h"
 
-// ELFIO
-#include <elfio/elfio.hpp>
-
 // MIPT-MIPS modules
 #include <infra/macro.h>
 
@@ -45,29 +42,6 @@ FuncMemory::FuncMemory( uint32 addr_bits,
         throw FuncMemoryBadMapping("Each page is too large ("s + std::to_string(page_size) + " bytes)");
 
     memory.resize(set_cnt);
-}
-
-void FuncMemory::load_elf_file( const std::string& executable_file_name)
-{
-    ELFIO::elfio reader;
-
-    if ( !reader.load( executable_file_name))
-        throw InvalidElfFile( executable_file_name);
-
-    for ( const auto& section : reader.sections)
-        load_elf_section( section);
-}
-
-void FuncMemory::load_elf_section( const ELFIO::section* section)
-{
-    if ( section->get_address() == 0)
-        return;
-
-    if ( section->get_name() == ".text")
-        startPC_addr = section->get_address();
-
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) Connecting ELFIO to our guidelines
-    memcpy_host_to_guest( section->get_address(), reinterpret_cast<const Byte*>(section->get_data()), section->get_size());
 }
 
 void FuncMemory::memcpy_host_to_guest( Addr dst, const Byte* src, size_t size)

--- a/simulator/infra/memory/memory.h
+++ b/simulator/infra/memory/memory.h
@@ -14,16 +14,8 @@
 #include <infra/types.h>
 
 // Generic C++
-#include <stdexcept>
 #include <string>
 #include <vector>
-
-struct InvalidElfFile final : Exception
-{
-    explicit InvalidElfFile(const std::string& name)
-        : Exception("Invalid elf file", name)
-    { }
-};
 
 struct FuncMemoryBadMapping final : Exception
 {
@@ -31,11 +23,6 @@ struct FuncMemoryBadMapping final : Exception
         : Exception("Invalid FuncMemory mapping", msg)
     { }
 };
-
-namespace ELFIO {
-    class section;
-} // namespace ELFIO
-
 class FuncMemory
 {
     public:
@@ -49,10 +36,12 @@ class FuncMemory
         template<typename T>
         void write( T value, Addr addr, T mask = all_ones<T>());
 
-        uint64 startPC() const { return startPC_addr; }
+        Addr startPC() const { return startPC_addr; }
+        void set_startPC(Addr value) { startPC_addr = value; }
+
         std::string dump() const;
         
-        void load_elf_file(const std::string& executable_file_name);
+        void memcpy_host_to_guest( Addr dst, const Byte* src, size_t size);
     private:
         const uint32 page_bits;
         const uint32 offset_bits;
@@ -89,9 +78,6 @@ class FuncMemory
         void alloc( Addr addr);
         void write_byte( Addr addr, Byte value);
         void alloc_and_write_byte( Addr addr, Byte value);
-        void memcpy_host_to_guest( Addr dst, const Byte* src, size_t size);
-        
-        void load_elf_section( const ELFIO::section* section);
 };
 
 #endif // #ifndef FUNC_MEMORY__FUNC_MEMORY_H

--- a/simulator/modules/core/perf_sim.cpp
+++ b/simulator/modules/core/perf_sim.cpp
@@ -5,6 +5,8 @@
 
 #include "perf_sim.h"
 
+#include <infra/memory/elf/elf_loader.h>
+
 #include <chrono>
 #include <iostream>
 
@@ -40,7 +42,7 @@ template<typename ISA>
 Trap PerfSim<ISA>::run( const std::string& tr, uint64 instrs_to_run)
 {
     force_halt = false;
-    memory->load_elf_file( tr);
+    ::load_elf_file( memory.get(), tr);
 
     writeback.init_checker( tr);
     writeback.set_instrs_to_run( instrs_to_run);

--- a/simulator/modules/core/t/unit_test.cpp
+++ b/simulator/modules/core/t/unit_test.cpp
@@ -9,6 +9,7 @@
 #include <catch.hpp>
 
 // Module
+#include <infra/memory/elf/elf_loader.h>    
 #include <mips/mips.h>
 #include <modules/writeback/writeback.h>
 


### PR DESCRIPTION
As we are going to expose 'memcpy' methods of FuncMemory, there is no
need to hide ELF loader inside the class, so it is a standalone function
now.