### PR TITLE
Simplify FuncMemory read and write interfaces

### DIFF
--- a/simulator/infra/instrcache/instr_cache_memory.h
+++ b/simulator/infra/instrcache/instr_cache_memory.h
@@ -15,13 +15,16 @@ template<typename Instr>
 class InstrMemory : public FuncMemory
 {
 public:
+        using DstType = decltype(std::declval<Instr>().get_v_dst());
+
         auto fetch( Addr pc) const { return read<uint32>( pc); }
         auto fetch_instr( Addr PC) { return Instr( fetch( PC), PC); }
 
         void load( Instr* instr) const
         {
-            using DstType = decltype(instr->get_v_dst());
-            instr->set_v_dst(read<DstType>(instr->get_mem_addr(), bitmask<DstType>(instr->get_mem_size() * 8)));
+            auto mask = bitmask<DstType>(instr->get_mem_size() * CHAR_BIT);
+            auto value = read<DstType>(instr->get_mem_addr(), mask);
+            instr->set_v_dst( value);
         }
 
         void store( const Instr& instr)
@@ -29,7 +32,10 @@ public:
             if (instr.get_mem_addr() == 0)
                 throw Exception("Store data to zero is an unhandled trap");
 
-            write( instr.get_v_src2(), instr.get_mem_addr(), instr.get_mask());
+            if (~instr.get_mask() == 0)
+                write<DstType, endian>( instr.get_v_src2(), instr.get_mem_addr());
+            else
+                write<DstType, endian>( instr.get_v_src2(), instr.get_mem_addr(), instr.get_mask());
         }
 
         void load_store(Instr* instr)

--- a/simulator/infra/instrcache/instr_cache_memory.h
+++ b/simulator/infra/instrcache/instr_cache_memory.h
@@ -33,9 +33,9 @@ public:
                 throw Exception("Store data to zero is an unhandled trap");
 
             if (~instr.get_mask() == 0)
-                write<DstType, endian>( instr.get_v_src2(), instr.get_mem_addr());
+                write<DstType>( instr.get_v_src2(), instr.get_mem_addr());
             else
-                write<DstType, endian>( instr.get_v_src2(), instr.get_mem_addr(), instr.get_mask());
+                write<DstType>( instr.get_v_src2(), instr.get_mem_addr(), instr.get_mask());
         }
 
         void load_store(Instr* instr)

--- a/simulator/infra/memory/memory.h
+++ b/simulator/infra/memory/memory.h
@@ -90,14 +90,13 @@ class FuncMemory
 template<typename T>
 T FuncMemory::read( Addr addr) const
 {
-    constexpr size_t amount_of_bytes = bitwidth<T> / CHAR_BIT;
-    Byte bytes[amount_of_bytes];
+    std::array<Byte, bitwidth<T> / CHAR_BIT> bytes;
 
-    memcpy_guest_to_host( bytes, addr, amount_of_bytes);
+    memcpy_guest_to_host( bytes.data(), addr, bytes.size());
 
     // Endian specific
     T value = 0;
-    for ( size_t i = 0; i < amount_of_bytes; ++i)
+    for ( size_t i = 0; i < bytes.size(); ++i) // NOLINTNEXTLINE
         value |= T( bytes[i]) << ( i * CHAR_BIT);
 
     return value;
@@ -106,14 +105,13 @@ T FuncMemory::read( Addr addr) const
 template<typename T>
 void FuncMemory::write( T value, Addr addr)
 {
-    constexpr size_t amount_of_bytes = bitwidth<T> / CHAR_BIT;
-    Byte bytes[amount_of_bytes];
+    std::array<Byte, bitwidth<T> / CHAR_BIT> bytes;
     
     // Endian specific
-    for ( size_t i = 0; i < amount_of_bytes; ++i)
+    for ( size_t i = 0; i < bytes.size(); ++i) // NOLINTNEXTLINE
         bytes[i] = Byte( value >> ( i * CHAR_BIT));
 
-    memcpy_host_to_guest( addr, bytes, amount_of_bytes);
+    memcpy_host_to_guest( addr, bytes.data(), bytes.size());
 }
 
 #endif // #ifndef FUNC_MEMORY__FUNC_MEMORY_H

--- a/simulator/infra/memory/memory.h
+++ b/simulator/infra/memory/memory.h
@@ -45,7 +45,10 @@ class FuncMemory
         template<typename T> T read( Addr addr, T mask) const { return read<T>( addr) & mask; }
 
         template<typename T> void write( T value, Addr addr);
-        template<typename T> void write( T value, Addr addr, T mask) { write( ( value & mask) | (read<T>( addr) & ~mask), addr); }
+        template<typename T> void write( T value, Addr addr, T mask)
+        {
+            write( ( value & mask) | (read<T>( addr) & ~mask), addr);
+        }
     private:
         const uint32 page_bits;
         const uint32 offset_bits;

--- a/simulator/infra/memory/memory.h
+++ b/simulator/infra/memory/memory.h
@@ -14,6 +14,7 @@
 #include <infra/types.h>
 
 // Generic C++
+#include <array>
 #include <climits>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Now we have the memcpy interfaces to FuncMemory, and we may use them
to simplify Uint/Int accessors to the memory.