### PR TITLE
Do not stop simulation on any trap

### DIFF
--- a/simulator/func_sim/func_sim.cpp
+++ b/simulator/func_sim/func_sim.cpp
@@ -72,7 +72,7 @@ Trap FuncSim<ISA>::run( const std::string& tr, uint64 instrs_to_run)
         const auto& instr = step();
         sout << instr << std::endl;
 
-        if ( instr.has_trap())
+        if ( instr.trap_type() == Trap::HALT)
             return instr.trap_type();
     }
     return Trap::NO_TRAP;

--- a/simulator/func_sim/t/unit_test.cpp
+++ b/simulator/func_sim/t/unit_test.cpp
@@ -43,7 +43,7 @@ TEST_CASE( "Run one instruction: Func_Sim")
 
 TEST_CASE( "Run_SMC_trace: Func_Sim")
 {
-    CHECK( FuncSim<MIPS32>().run_no_limit( smc_code) == Trap::SYSCALL);
+    CHECK_THROWS_AS( FuncSim<MIPS32>().run_no_limit( smc_code), BearingLost);
 }
 
 TEST_CASE( "Torture_Test: Func_Sim")


### PR DESCRIPTION
Unfortunately, we have some traps in our Torture Test,
and they stop functional simulation completely