### PR TITLE
Add duplicate_to method to FuncMemory

### DIFF
--- a/simulator/func_sim/func_sim.cpp
+++ b/simulator/func_sim/func_sim.cpp
@@ -65,6 +65,14 @@ void FuncSim<ISA>::init( const std::string& tr)
 }
 
 template <typename ISA>
+void FuncSim<ISA>::init( const Memory& other_mem)
+{
+    other_mem.duplicate_to( mem.get());
+    PC = mem->startPC();
+    nops_in_a_row = 0;
+}
+
+template <typename ISA>
 Trap FuncSim<ISA>::run( const std::string& tr, uint64 instrs_to_run)
 {
     init( tr);

--- a/simulator/func_sim/func_sim.h
+++ b/simulator/func_sim/func_sim.h
@@ -40,6 +40,7 @@ class FuncSim : public Simulator
         explicit FuncSim( bool log = false);
 
         void init( const std::string& tr);
+        void init( const Memory& other_mem);
         FuncInstr step();
         Trap run(const std::string& tr, uint64 instrs_to_run) final;
         void set_target(const Target& target) final {

--- a/simulator/infra/memory/memory.cpp
+++ b/simulator/infra/memory/memory.cpp
@@ -108,6 +108,16 @@ bool FuncMemory::check( Addr addr) const
     return !set.empty() && !set[get_page(addr)].empty();
 }
 
+void FuncMemory::duplicate_to( FuncMemory* target) const
+{
+    target->set_startPC( startPC());
+    for ( auto set_it = memory.begin(); set_it != memory.end(); ++set_it)
+        for ( auto page_it = set_it->begin(); page_it != set_it->end(); ++page_it)
+            target->memcpy_host_to_guest( get_addr( set_it, page_it, page_it->begin()),
+                                          page_it->data(),
+                                          page_it->size());
+}
+
 std::string FuncMemory::dump() const
 {
     std::ostringstream oss;

--- a/simulator/infra/memory/memory.h
+++ b/simulator/infra/memory/memory.h
@@ -22,8 +22,8 @@
 
 struct FuncMemoryBadMapping final : Exception
 {
-    explicit FuncMemoryBadMapping(const std::string& msg)
-        : Exception("Invalid FuncMemory mapping", msg)
+    explicit FuncMemoryBadMapping( const std::string& msg)
+        : Exception( "Invalid FuncMemory mapping", msg)
     { }
 };
 
@@ -44,7 +44,7 @@ class FuncMemory
         size_t memcpy_guest_to_host( Byte* dst, Addr src, size_t size) const;
         size_t memcpy_guest_to_host_noexcept( Byte* dst, Addr src, size_t size) const noexcept;
 
-        void duplicate_to( FuncMemory* memory) const;
+        void duplicate_to( FuncMemory* target) const;
 
         template<typename T, Endian endian> T read( Addr addr) const;
         template<typename T, Endian endian> T read( Addr addr, T mask) const { return read<T, endian>( addr) & mask; }
@@ -52,7 +52,7 @@ class FuncMemory
         template<typename T, Endian endian> void write( T value, Addr addr);
         template<typename T, Endian endian> void write( T value, Addr addr, T mask)
         {
-            T combined_value = (value & mask) | (read<T, endian>( addr) & ~mask);
+            T combined_value = ( value & mask) | (read<T, endian>( addr) & ~mask);
             write<T, endian>( combined_value, addr);
         }
     private:

--- a/simulator/infra/memory/memory.h
+++ b/simulator/infra/memory/memory.h
@@ -44,6 +44,8 @@ class FuncMemory
         size_t memcpy_guest_to_host( Byte* dst, Addr src, size_t size) const;
         size_t memcpy_guest_to_host_noexcept( Byte* dst, Addr src, size_t size) const noexcept;
 
+        void duplicate_to( FuncMemory* memory) const;
+
         template<typename T, Endian endian> T read( Addr addr) const;
         template<typename T, Endian endian> T read( Addr addr, T mask) const { return read<T, endian>( addr) & mask; }
 

--- a/simulator/infra/memory/t/unit_test.cpp
+++ b/simulator/infra/memory/t/unit_test.cpp
@@ -219,40 +219,6 @@ TEST_CASE( "Func_memory: Dump")
     );
 }
 
-TEST_CASE( "Func_memory: Invariancy")
-{
-    FuncMemory mem1;
-    FuncMemory mem2( 48, 15, 10);
-    ::load_elf_file( &mem1, valid_elf_file);
-    ::load_elf_file( &mem2, valid_elf_file);
-    
-    CHECK( mem1.dump() == mem2.dump());
-
-    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem2.read<uint32, Endian::little>( dataSectAddr));
-    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr + 1, 0xFFFFFFull) == mem2.read<uint32, Endian::little>( dataSectAddr + 1, 0xFFFFFFull));
-    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr + 2, 0xFFFFull) == mem2.read<uint32, Endian::little>( dataSectAddr + 2, 0xFFFFull));
-    CHECK( mem1.read<uint16, Endian::little>( dataSectAddr + 2) == mem2.read<uint16, Endian::little>( dataSectAddr + 2));
-    CHECK( mem1.read<uint8, Endian::little>( dataSectAddr + 3) == mem2.read<uint8, Endian::little>( dataSectAddr + 3));
-    CHECK( mem1.read<uint8, Endian::little>( 0x300000) == mem2.read<uint8, Endian::little>( 0x300000));
-    
-    mem1.write<uint8, Endian::little>( 1, dataSectAddr);
-    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) != mem2.read<uint32, Endian::little>( dataSectAddr));
-
-    mem2.write<uint8, Endian::little>( 1, dataSectAddr);
-    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem2.read<uint32, Endian::little>( dataSectAddr));
-
-    mem1.write<uint16, Endian::little>( 0x7777, dataSectAddr + 1);
-    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) != mem2.read<uint32, Endian::little>( dataSectAddr));
-
-    mem2.write<uint16, Endian::little>( 0x7777, dataSectAddr + 1);
-    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem2.read<uint32, Endian::little>( dataSectAddr));
-
-    mem1.write<uint32, Endian::little>( 0x00000000, dataSectAddr, 0xFFFFFFFFull);
-    mem2.write<uint32, Endian::little>( 0x00000000, dataSectAddr, 0xFFFFFFFFull);
-
-    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem1.read<uint32, Endian::little>( dataSectAddr));
-}
-
 TEST_CASE( "Func_memory: Duplicate")
 {
     FuncMemory mem1;

--- a/simulator/infra/memory/t/unit_test.cpp
+++ b/simulator/infra/memory/t/unit_test.cpp
@@ -252,3 +252,37 @@ TEST_CASE( "Func_memory: Invariancy")
 
     CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem1.read<uint32, Endian::little>( dataSectAddr));
 }
+
+TEST_CASE( "Func_memory: Duplicate")
+{
+    FuncMemory mem1;
+    FuncMemory mem2( 48, 15, 10);
+    ::load_elf_file( &mem1, valid_elf_file);
+    mem1.duplicate_to( &mem2);
+    
+    CHECK( mem1.dump() == mem2.dump());
+
+    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem2.read<uint32, Endian::little>( dataSectAddr));
+    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr + 1, 0xFFFFFFull) == mem2.read<uint32, Endian::little>( dataSectAddr + 1, 0xFFFFFFull));
+    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr + 2, 0xFFFFull) == mem2.read<uint32, Endian::little>( dataSectAddr + 2, 0xFFFFull));
+    CHECK( mem1.read<uint16, Endian::little>( dataSectAddr + 2) == mem2.read<uint16, Endian::little>( dataSectAddr + 2));
+    CHECK( mem1.read<uint8, Endian::little>( dataSectAddr + 3) == mem2.read<uint8, Endian::little>( dataSectAddr + 3));
+    CHECK( mem1.read<uint8, Endian::little>( 0x300000) == mem2.read<uint8, Endian::little>( 0x300000));
+    
+    mem1.write<uint8, Endian::little>( 1, dataSectAddr);
+    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) != mem2.read<uint32, Endian::little>( dataSectAddr));
+
+    mem2.write<uint8, Endian::little>( 1, dataSectAddr);
+    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem2.read<uint32, Endian::little>( dataSectAddr));
+
+    mem1.write<uint16, Endian::little>( 0x7777, dataSectAddr + 1);
+    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) != mem2.read<uint32, Endian::little>( dataSectAddr));
+
+    mem2.write<uint16, Endian::little>( 0x7777, dataSectAddr + 1);
+    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem2.read<uint32, Endian::little>( dataSectAddr));
+
+    mem1.write<uint32, Endian::little>( 0x00000000, dataSectAddr, 0xFFFFFFFFull);
+    mem2.write<uint32, Endian::little>( 0x00000000, dataSectAddr, 0xFFFFFFFFull);
+
+    CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem1.read<uint32, Endian::little>( dataSectAddr));
+}

--- a/simulator/modules/core/perf_sim.cpp
+++ b/simulator/modules/core/perf_sim.cpp
@@ -44,7 +44,7 @@ Trap PerfSim<ISA>::run( const std::string& tr, uint64 instrs_to_run)
     force_halt = false;
     ::load_elf_file( memory.get(), tr);
 
-    writeback.init_checker( tr);
+    writeback.init_checker( *memory);
     writeback.set_instrs_to_run( instrs_to_run);
 
     set_target( Target( memory->startPC(), 0));

--- a/simulator/modules/writeback/writeback.cpp
+++ b/simulator/modules/writeback/writeback.cpp
@@ -13,6 +13,12 @@ Writeback<ISA>::Writeback(bool log) : Log( log), checker( false)
 }
 
 template <typename ISA>
+void Writeback<ISA>::init_checker( const Memory& mem)
+{
+    checker.init( mem);
+}
+
+template <typename ISA>
 void Writeback<ISA>::clock( Cycle cycle)
 {
     sout << "wb      cycle " << std::dec << cycle << ": ";

--- a/simulator/modules/writeback/writeback.h
+++ b/simulator/modules/writeback/writeback.h
@@ -31,6 +31,7 @@ class Writeback : public Log
     using FuncInstr = typename ISA::FuncInstr;
     using Instr = PerfInstr<FuncInstr>;
     using RegisterUInt = typename ISA::RegisterUInt;
+    using Memory = typename ISA::Memory;
 private:
     /* Instrumentation */
     uint64 instrs_to_run = 0;
@@ -56,9 +57,9 @@ public:
     explicit Writeback( bool log);
     void clock( Cycle cycle);
     void set_RF( RF<ISA>* value) { rf = value; }
+    void init_checker( const Memory& mem);
     void set_target( const Target& value) { checker.set_target( value); }
     void set_instrs_to_run( uint64 value) { instrs_to_run = value; }
-    void init_checker( const std::string& tr) { checker.init( tr); }
     auto get_executed_instrs() const { return executed_instrs; }
 };
 


### PR DESCRIPTION
Now we can open ELF files only once, but my actual motivation was decoupling ELF loader out of Writeback internals to support loads from two ELFs, or from outer I/O, or anything else.