### PR TITLE
Move load/store functions to FuncMemory

### DIFF
--- a/simulator/infra/instrcache/instr_cache_memory.h
+++ b/simulator/infra/instrcache/instr_cache_memory.h
@@ -6,7 +6,6 @@
 #ifndef INSTR_CACHE_H
 #define INSTR_CACHE_H
 
-#include <infra/exception.h>
 #include <infra/instrcache/LRUCache.h>
 #include <infra/memory/memory.h>
 #include <infra/types.h>
@@ -15,37 +14,8 @@ template<typename Instr>
 class InstrMemory : public FuncMemory
 {
 public:
-        static const constexpr Endian endian = Instr::endian;
-        using DstType = decltype(std::declval<Instr>().get_v_dst());
-
-        auto fetch( Addr pc) const { return read<uint32, endian>( pc); }
-        auto fetch_instr( Addr PC) { return Instr( fetch( PC), PC); }
-
-        void load( Instr* instr) const
-        {
-            auto mask = bitmask<DstType>(instr->get_mem_size() * CHAR_BIT);
-            auto value = read<DstType, endian>(instr->get_mem_addr(), mask);
-            instr->set_v_dst( value);
-        }
-
-        void store( const Instr& instr)
-        {
-            if (instr.get_mem_addr() == 0)
-                throw Exception("Store data to zero is an unhandled trap");
-
-            if (~instr.get_mask() == 0)
-                write<DstType, endian>( instr.get_v_src2(), instr.get_mem_addr());
-            else
-                write<DstType, endian>( instr.get_v_src2(), instr.get_mem_addr(), instr.get_mask());
-        }
-
-        void load_store(Instr* instr)
-        {
-            if (instr->is_load())
-                load(instr);
-            else if (instr->is_store())
-                store(*instr);
-        }
+    auto fetch( Addr pc) const { return read<uint32, Instr::endian>( pc); }
+    auto fetch_instr( Addr PC) { return Instr( fetch( PC), PC); }
 };
 
 #ifndef INSTR_CACHE_CAPACITY
@@ -55,22 +25,22 @@ public:
 template<typename Instr>
 class InstrMemoryCached : public InstrMemory<Instr>
 {
-        LRUCache<Addr, Instr, INSTR_CACHE_CAPACITY> instr_cache{};
-    public:
-        Instr fetch_instr( Addr PC)
-        {
-            const auto [found, value] = instr_cache.find( PC);
-            if ( found && value.is_same_bytes( this->fetch( PC))) {
-                instr_cache.touch( PC);
-                return value;
-            }
-            if ( found)
-                instr_cache.erase( PC);
-
-            const Instr& instr = InstrMemory<Instr>::fetch_instr( PC);
-            instr_cache.update( PC, instr);
-            return instr;
+    LRUCache<Addr, Instr, INSTR_CACHE_CAPACITY> instr_cache{};
+public:
+    Instr fetch_instr( Addr PC)
+    {
+        const auto [found, value] = instr_cache.find( PC);
+        if ( found && value.is_same_bytes( this->fetch( PC))) {
+            instr_cache.touch( PC);
+            return value;
         }
+        if ( found)
+            instr_cache.erase( PC);
+
+        const Instr& instr = InstrMemory<Instr>::fetch_instr( PC);
+        instr_cache.update( PC, instr);
+        return instr;
+    }
 };
 
 #endif // INSTR_CACHE_H

--- a/simulator/infra/memory/memory.h
+++ b/simulator/infra/memory/memory.h
@@ -50,9 +50,11 @@ class FuncMemory
         template<typename T, Endian endian> void write( T value, Addr addr);
         template<typename T, Endian endian> void write( T value, Addr addr, T mask)
         {
-            T combined_value = (value & mask) | (read<T, endian>( addr) & ~mask);
+            T combined_value = (value & mask) | ( read<T, endian>( addr) & ~mask);
             write<T, endian>( combined_value, addr);
         }
+
+        template<typename Instr> void load_store( Instr* instr);
     private:
         const uint32 page_bits;
         const uint32 offset_bits;
@@ -89,6 +91,9 @@ class FuncMemory
         void alloc( Addr addr);
         void write_byte( Addr addr, Byte value);
         void alloc_and_write_byte( Addr addr, Byte value);
+
+        template<typename Instr> void load( Instr* instr) const;
+        template<typename Instr> void store( const Instr& instr);
 };
 
 template<typename T, Endian endian>
@@ -105,6 +110,39 @@ void FuncMemory::write( T value, Addr addr)
 {
     const auto& bytes = unpack_array<T, endian>( value);
     memcpy_host_to_guest( addr, bytes.data(), bytes.size());
+}
+
+template<typename Instr>
+void FuncMemory::load( Instr* instr) const
+{
+    static const constexpr Endian endian = Instr::endian;
+    using DstType = decltype( std::declval<Instr>().get_v_dst());
+    auto mask = bitmask<DstType>( instr->get_mem_size() * CHAR_BIT);
+    auto value = read<DstType, endian>( instr->get_mem_addr(), mask);
+    instr->set_v_dst( value);
+}
+
+template<typename Instr>
+void FuncMemory::store( const Instr& instr)
+{
+    static const constexpr Endian endian = Instr::endian;
+    using DstType = decltype( std::declval<Instr>().get_v_dst());
+    if ( instr.get_mem_addr() == 0)
+        throw Exception("Store data to zero is an unhandled trap");
+
+    if ( ~instr.get_mask() == 0)
+        write<DstType, endian>( instr.get_v_src2(), instr.get_mem_addr());
+    else
+        write<DstType, endian>( instr.get_v_src2(), instr.get_mem_addr(), instr.get_mask());
+}
+
+template<typename Instr>
+void FuncMemory::load_store(Instr* instr)
+{
+    if ( instr->is_load())
+        load( instr);
+    else if ( instr->is_store())
+        store( *instr);
 }
 
 #endif // #ifndef FUNC_MEMORY__FUNC_MEMORY_H


### PR DESCRIPTION
Now we may use InstrMemory only in the classes which actually fetch instructions, and reduce amount of templates throughout the code in the next commit.