### PR TITLE
Build MIPS traces only if they are used in testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ before_build:
 - 7z x mips-linux-gnu.zip
 
 build_script:
-- bash -lc "cd /c/projects/mipt-mips/traces/; make"
+- bash -lc "cd /c/projects/mipt-mips/traces/; make tt"
 - mkdir build
 - cd build
 - cmake ../simulator -G "%CMAKEFILE%"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
     fi
 
 before_script:
-  - cd $TRAVIS_BUILD_DIR/traces && make
+  - cd $TRAVIS_BUILD_DIR/traces && make tt
   - cd $TRAVIS_BUILD_DIR/simulator
   - mkdir release && cd release
   - cmake .. -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Now we build in 16 minutes with Appveyor (instead of 1 hour). More compilation speed up is expected with detemplatization of some MIPT-MIPS modules.