### PR TITLE
Make ownership of FuncMemory external to Simulator

### DIFF
--- a/simulator/func_sim/func_sim.cpp
+++ b/simulator/func_sim/func_sim.cpp
@@ -4,12 +4,15 @@
  */
  
 #include "func_sim.h"
-#include <memory/elf/elf_loader.h>
 
 template <typename ISA>
-FuncSim<ISA>::FuncSim( bool log) : Simulator( log), mem( FuncMemory::create_hierarchied_memory())
+FuncSim<ISA>::FuncSim( bool log) : Simulator( log) { }
+
+template <typename ISA>
+void FuncSim<ISA>::set_memory( FuncMemory* m)
 {
-    imem.set_memory( mem.get());
+    mem = m;
+    imem.set_memory( m);
 }
 
 template <typename ISA>
@@ -60,25 +63,16 @@ typename FuncSim<ISA>::FuncInstr FuncSim<ISA>::step()
 }
 
 template <typename ISA>
-void FuncSim<ISA>::init( const std::string& tr)
+void FuncSim<ISA>::init()
 {
-    ::load_elf_file( mem.get(), tr);
     PC = mem->startPC();
     nops_in_a_row = 0;
 }
 
 template <typename ISA>
-void FuncSim<ISA>::init( const FuncMemory& other_mem)
+Trap FuncSim<ISA>::run( uint64 instrs_to_run)
 {
-    other_mem.duplicate_to( mem.get());
-    PC = mem->startPC();
-    nops_in_a_row = 0;
-}
-
-template <typename ISA>
-Trap FuncSim<ISA>::run( const std::string& tr, uint64 instrs_to_run)
-{
-    init( tr);
+    init();
     for ( uint32 i = 0; i < instrs_to_run; ++i) {
         const auto& instr = step();
         sout << instr << std::endl;

--- a/simulator/func_sim/func_sim.h
+++ b/simulator/func_sim/func_sim.h
@@ -31,7 +31,7 @@ class FuncSim : public Simulator
         RF<ISA> rf;
         Addr PC = NO_VAL32;
         uint64 sequence_id = 0;
-        std::unique_ptr<FuncMemory> mem = nullptr;
+        FuncMemory* mem = nullptr;
         InstrMemoryCached<FuncInstr> imem;
 
         uint64 nops_in_a_row = 0;
@@ -40,10 +40,11 @@ class FuncSim : public Simulator
     public:
         explicit FuncSim( bool log = false);
 
-        void init( const std::string& tr);
-        void init( const FuncMemory& other_mem);
+        void set_memory( FuncMemory* memory) final;
+        void init();
+        void init_checker() final { };
         FuncInstr step();
-        Trap run(const std::string& tr, uint64 instrs_to_run) final;
+        Trap run(uint64 instrs_to_run) final;
         void set_target(const Target& target) final {
             PC = target.address;
             sequence_id = target.sequence_id;

--- a/simulator/func_sim/t/unit_test.cpp
+++ b/simulator/func_sim/t/unit_test.cpp
@@ -10,6 +10,7 @@
 
 // Module
 #include <memory/elf/elf_loader.h>    
+#include <memory/memory.h>
 #include <mips/mips.h>
 
 #include <sstream>
@@ -17,44 +18,71 @@
 static const std::string valid_elf_file = TEST_PATH "/tt.core32.out";
 static const std::string smc_code = TEST_PATH "/smc.out";
 
+// TODO: remove that class, use true FuncSim interfaces instead
+template <typename ISA>
+struct FuncSimAndMemory : FuncSim<ISA>
+{
+    std::unique_ptr<FuncMemory> mem;
+
+    FuncSimAndMemory() : FuncSim<ISA>(), mem( FuncMemory::create_hierarchied_memory())
+    {
+       this->set_memory( mem.get());
+    }
+
+    void init( const std::string& tr) {
+        ::load_elf_file( mem.get(), tr);
+        FuncSim<ISA>::init();
+    }
+
+    auto run_trace( const std::string& tr, uint64 steps) {
+        ::load_elf_file( mem.get(), tr);
+        return FuncSim<ISA>::run( steps);
+    }
+
+    auto run_trace_no_limit( const std::string& tr) {
+        ::load_elf_file( mem.get(), tr);
+        return FuncSim<ISA>::run_no_limit();
+    }
+};
+
 TEST_CASE( "Process_Wrong_Args_Of_Constr: Func_Sim_init")
 {
     // Just call a constructor
-    CHECK_NOTHROW( FuncSim<MIPS32>() );
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS32>() );
 
     // Call constructor and init
-    CHECK_NOTHROW( FuncSim<MIPS32>().init( valid_elf_file) );
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS32>().init( valid_elf_file) );
 
     // Do bad init
-    CHECK_THROWS_AS( FuncSim<MIPS32>().init( "./1234567890/qwertyuop"), InvalidElfFile);
+    CHECK_THROWS_AS( FuncSimAndMemory<MIPS32>().init( "./1234567890/qwertyuop"), InvalidElfFile);
 }
 
 TEST_CASE( "Make_A_Step: Func_Sim")
 {
-    FuncSim<MIPS32> simulator;
+    FuncSimAndMemory<MIPS32> simulator;
     simulator.init( valid_elf_file);
     CHECK( simulator.step().string_dump().find("lui $at, 0x41\t [ $at = 0x410000 ]") != std::string::npos);
 }
 
 TEST_CASE( "Run one instruction: Func_Sim")
 {
-    CHECK( FuncSim<MIPS32>().run( smc_code, 1) == Trap::NO_TRAP);
+    CHECK( FuncSimAndMemory<MIPS32>().run_trace( smc_code, 1) == Trap::NO_TRAP);
 }
 
 TEST_CASE( "Run_SMC_trace: Func_Sim")
 {
-    CHECK_NOTHROW( FuncSim<MIPS32>().run_no_limit( smc_code));
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS32>().run_trace_no_limit( smc_code));
 }
 
 TEST_CASE( "Torture_Test: Func_Sim")
 {
     // MIPS 32 Little-endian
-    CHECK_NOTHROW( FuncSim<MIPS32>().run_no_limit( TEST_PATH "/tt.core.universal.out") );
-    CHECK_NOTHROW( FuncSim<MIPS32>().run_no_limit( TEST_PATH "/tt.core32.out") );
-    CHECK_NOTHROW( FuncSim<MIPS32>().run_no_limit( TEST_PATH "/tt.core32.le.out") );
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS32>().run_trace_no_limit( TEST_PATH "/tt.core.universal.out") );
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS32>().run_trace_no_limit( TEST_PATH "/tt.core32.out") );
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS32>().run_trace_no_limit( TEST_PATH "/tt.core32.le.out") );
 
     // MIPS 64 Little-Endian
-    CHECK_NOTHROW( FuncSim<MIPS64>().run_no_limit( TEST_PATH "/tt.core.universal.out") );
-    CHECK_NOTHROW( FuncSim<MIPS64>().run_no_limit( TEST_PATH "/tt.core64.out") );
-    CHECK_NOTHROW( FuncSim<MIPS64>().run_no_limit( TEST_PATH "/tt.core64.le.out") );
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS64>().run_trace_no_limit( TEST_PATH "/tt.core.universal.out") );
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS64>().run_trace_no_limit( TEST_PATH "/tt.core64.out") );
+    CHECK_NOTHROW( FuncSimAndMemory<MIPS64>().run_trace_no_limit( TEST_PATH "/tt.core64.le.out") );
 }

--- a/simulator/func_sim/t/unit_test.cpp
+++ b/simulator/func_sim/t/unit_test.cpp
@@ -64,6 +64,14 @@ TEST_CASE( "Make_A_Step: Func_Sim")
     CHECK( simulator.step().string_dump().find("lui $at, 0x41\t [ $at = 0x410000 ]") != std::string::npos);
 }
 
+TEST_CASE( "FuncSim: make a step with checker")
+{
+    FuncSimAndMemory<MIPS32> simulator;
+    simulator.init( valid_elf_file);
+    simulator.init_checker();
+    CHECK( simulator.step().string_dump().find("lui $at, 0x41\t [ $at = 0x410000 ]") != std::string::npos);
+}
+
 TEST_CASE( "Run one instruction: Func_Sim")
 {
     CHECK( FuncSimAndMemory<MIPS32>().run_trace( smc_code, 1) == Trap::NO_TRAP);

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -6,6 +6,8 @@
 
 /* Simulator modules. */
 #include <infra/config/config.h>
+#include <memory/elf/elf_loader.h>
+#include <memory/memory.h>
 #include <simulator.h>
 
 namespace config {
@@ -14,9 +16,14 @@ namespace config {
 } // namespace config
 
 int main( int argc, const char* argv[]) try {
-    /* Analysing and handling of inserted arguments */
     config::handleArgs( argc, argv, 1);
-    Simulator::create_configured_simulator()->run( config::binary_filename, config::num_steps);
+    auto memory = FuncMemory::create_hierarchied_memory();
+    ::load_elf_file( memory.get(), config::binary_filename);
+
+    auto sim = Simulator::create_configured_simulator();
+    sim->set_memory( memory.get());
+    sim->init_checker();
+    sim->run( config::num_steps);
     return 0;
 }
 catch (const config::HelpOption& e) {

--- a/simulator/memory/t/unit_test.cpp
+++ b/simulator/memory/t/unit_test.cpp
@@ -266,3 +266,4 @@ TEST_CASE( "Func_memory: Duplicate")
 
     CHECK( mem1.read<uint32, Endian::little>( dataSectAddr) == mem1.read<uint32, Endian::little>( dataSectAddr));
 }
+

--- a/simulator/modules/core/perf_sim.cpp
+++ b/simulator/modules/core/perf_sim.cpp
@@ -12,7 +12,6 @@
 template <typename ISA>
 PerfSim<ISA>::PerfSim(bool log) : 
     CycleAccurateSimulator( log),
-    memory( FuncMemory::create_hierarchied_memory()),
     fetch( log),
     decode( log),
     execute( log),
@@ -22,12 +21,18 @@ PerfSim<ISA>::PerfSim(bool log) :
     wp_core_2_fetch_target = make_write_port<Target>("CORE_2_FETCH_TARGET", PORT_BW, PORT_FANOUT);
     rp_halt = make_read_port<bool>("WRITEBACK_2_CORE_HALT", PORT_LATENCY);
 
-    fetch.set_memory( memory.get());
     decode.set_RF( &rf);
-    mem.set_memory( memory.get());
     writeback.set_RF( &rf);
 
     init_ports();
+}
+
+template <typename ISA>
+void PerfSim<ISA>::set_memory( FuncMemory* m)
+{
+    memory = m;
+    fetch.set_memory( m);
+    mem.set_memory( m);
 }
 
 template <typename ISA>
@@ -38,12 +43,10 @@ void PerfSim<ISA>::set_target( const Target& target)
 }
 
 template<typename ISA>
-Trap PerfSim<ISA>::run( const std::string& tr, uint64 instrs_to_run)
+Trap PerfSim<ISA>::run( uint64 instrs_to_run)
 {
     force_halt = false;
-    ::load_elf_file( memory.get(), tr);
 
-    writeback.init_checker( *memory);
     writeback.set_instrs_to_run( instrs_to_run);
 
     set_target( Target( memory->startPC(), 0));

--- a/simulator/modules/core/perf_sim.h
+++ b/simulator/modules/core/perf_sim.h
@@ -27,11 +27,13 @@ class PerfSim : public CycleAccurateSimulator
 {
 public:
     explicit PerfSim( bool log);
-    ~PerfSim() final { destroy_ports(); }
-    Trap run( const std::string& tr, uint64 instrs_to_run) final;
+    ~PerfSim() override { destroy_ports(); }
+    Trap run( uint64 instrs_to_run) final;
     void set_target( const Target& target) final;
+    void set_memory( FuncMemory* memory) final;
     void clock() final;
     void halt() final { force_halt = true; }
+    void init_checker() final { writeback.init_checker( *memory); }
 
     // Rule of five
     PerfSim( const PerfSim&) = delete;
@@ -48,7 +50,8 @@ private:
 
     /* simulator units */
     RF<ISA> rf;
-    std::unique_ptr<FuncMemory> memory = nullptr;
+    FuncMemory* memory = nullptr;
+
     Fetch<ISA> fetch;
     Decode<ISA> decode;
     Execute<ISA> execute;

--- a/simulator/modules/core/t/unit_test.cpp
+++ b/simulator/modules/core/t/unit_test.cpp
@@ -9,46 +9,70 @@
 #include <catch.hpp>
 
 // Module
-#include <memory/elf/elf_loader.h>    
+#include <memory/elf/elf_loader.h>
 #include <mips/mips.h>
 #include <modules/writeback/writeback.h>
 
 static const std::string valid_elf_file = TEST_PATH "/tt.core32.out";
 static const std::string smc_code = TEST_PATH "/smc.out";
 
+// TODO: remove that class, use true FuncSim interfaces instead
+template <typename ISA>
+struct PerfSimAndMemory : PerfSim<ISA>
+{
+    std::unique_ptr<FuncMemory> mem;
+
+    PerfSimAndMemory(bool log) : PerfSim<ISA>(log), mem( FuncMemory::create_hierarchied_memory())
+    {
+       this->set_memory( mem.get());
+    }
+
+    auto run_trace( const std::string& tr, uint64 steps) {
+        ::load_elf_file( mem.get(), tr);
+        this->init_checker();
+        return PerfSim<ISA>::run( steps);
+    }
+
+    auto run_trace_no_limit( const std::string& tr) {
+        ::load_elf_file( mem.get(), tr);
+        this->init_checker();
+        return PerfSim<ISA>::run_no_limit();
+    }
+};
+
 TEST_CASE( "Perf_Sim_init: Process_Correct_Args_Of_Constr")
 {
     // Just call a constructor
-    CHECK_NOTHROW( PerfSim<MIPS32>( false) );
+    CHECK_NOTHROW( PerfSimAndMemory<MIPS32>( false) );
 }
 
 TEST_CASE( "Perf_Sim_init: Make_A_Step")
 {
     // Call constructor and run one instr
-    CHECK_NOTHROW( PerfSim<MIPS32>( false).run( valid_elf_file, 1) );
+    CHECK_NOTHROW( PerfSimAndMemory<MIPS32>( false).run_trace( valid_elf_file, 1) );
 }
 
 TEST_CASE( "Perf_Sim_init: Process_Wrong_Args")
 {
     // Do bad init
-    CHECK_THROWS_AS( PerfSim<MIPS32>( false).run( "./1234567890/qwertyuop", 1), InvalidElfFile);
+    CHECK_THROWS_AS( PerfSimAndMemory<MIPS32>( false).run_trace( "./1234567890/qwertyuop", 1), InvalidElfFile);
 }
 
 TEST_CASE( "Torture_Test: Perf_Sim")
 {
     // MIPS 32 Little-Endian
-    CHECK_NOTHROW( PerfSim<MIPS32>( false).run_no_limit( TEST_PATH "/tt.core.universal.out") );
-    CHECK_NOTHROW( PerfSim<MIPS32>( false).run_no_limit( TEST_PATH "/tt.core32.out") );
-    CHECK_NOTHROW( PerfSim<MIPS32>( false).run_no_limit( TEST_PATH "/tt.core32.le.out") );
+    CHECK_NOTHROW( PerfSimAndMemory<MIPS32>( false).run_trace_no_limit( TEST_PATH "/tt.core.universal.out") );
+    CHECK_NOTHROW( PerfSimAndMemory<MIPS32>( false).run_trace_no_limit( TEST_PATH "/tt.core32.out") );
+    CHECK_NOTHROW( PerfSimAndMemory<MIPS32>( false).run_trace_no_limit( TEST_PATH "/tt.core32.le.out") );
 
     // MIPS 64 Little-Endian
-    CHECK_NOTHROW( PerfSim<MIPS64>( false).run_no_limit( TEST_PATH "/tt.core.universal.out") );
-    CHECK_NOTHROW( PerfSim<MIPS64>( false).run_no_limit( TEST_PATH "/tt.core64.out") );
-    CHECK_NOTHROW( PerfSim<MIPS64>( false).run_no_limit( TEST_PATH "/tt.core64.le.out") );
+    CHECK_NOTHROW( PerfSimAndMemory<MIPS64>( false).run_trace_no_limit( TEST_PATH "/tt.core.universal.out") );
+    CHECK_NOTHROW( PerfSimAndMemory<MIPS64>( false).run_trace_no_limit( TEST_PATH "/tt.core64.out") );
+    CHECK_NOTHROW( PerfSimAndMemory<MIPS64>( false).run_trace_no_limit( TEST_PATH "/tt.core64.le.out") );
 }
 
 TEST_CASE( "Perf_Sim: Run_SMC_Trace")
 {
-    CHECK_THROWS_AS( PerfSim<MIPS32>( false).run_no_limit( smc_code), CheckerMismatch);
+    CHECK_THROWS_AS( PerfSimAndMemory<MIPS32>( false).run_trace_no_limit( smc_code), CheckerMismatch);
 }
 

--- a/simulator/modules/core/t/unit_test.cpp
+++ b/simulator/modules/core/t/unit_test.cpp
@@ -71,7 +71,16 @@ TEST_CASE( "Torture_Test: Perf_Sim")
     CHECK_NOTHROW( PerfSimAndMemory<MIPS64>( false).run_trace_no_limit( TEST_PATH "/tt.core64.le.out") );
 }
 
-TEST_CASE( "Perf_Sim: Run_SMC_Trace")
+TEST_CASE( "Perf_Sim: Run_SMC_Trace_WithoutChecker")
+{
+    PerfSim<MIPS32> sim( false);
+    auto mem = FuncMemory::create_hierarchied_memory();
+    ::load_elf_file( mem.get(), smc_code);
+    sim.set_memory( mem.get());
+    CHECK( sim.run_no_limit( ) == Trap::NO_TRAP);
+}
+
+TEST_CASE( "Perf_Sim: Run_SMC_Trace_WithChecker")
 {
     CHECK_THROWS_AS( PerfSimAndMemory<MIPS32>( false).run_trace_no_limit( smc_code), CheckerMismatch);
 }

--- a/simulator/modules/writeback/writeback.h
+++ b/simulator/modules/writeback/writeback.h
@@ -36,8 +36,16 @@ private:
     uint64 instrs_to_run = 0;
     uint64 executed_instrs = 0;
     Cycle last_writeback_cycle = 0_cl;
-    FuncSim<ISA> checker;
-    void check( const FuncInstr& instr);
+
+    class Checker {
+        std::unique_ptr<FuncSim<ISA>> sim;
+        std::unique_ptr<FuncMemory> memory;
+        bool active = false;
+    public:
+        void check( const FuncInstr& instr);
+        void init( const FuncMemory& mem);
+        void set_target( const Target& value);
+    } checker;
 
     /* Simulator internals */
     RF<ISA>* rf = nullptr;
@@ -56,7 +64,7 @@ public:
     explicit Writeback( bool log);
     void clock( Cycle cycle);
     void set_RF( RF<ISA>* value) { rf = value; }
-    void init_checker( const FuncMemory& mem);
+    void init_checker( const FuncMemory& mem) { checker.init( mem); }
     void set_target( const Target& value) { checker.set_target( value); }
     void set_instrs_to_run( uint64 value) { instrs_to_run = value; }
     auto get_executed_instrs() const { return executed_instrs; }

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -17,9 +17,12 @@ class Simulator : public Log {
 public:
     explicit Simulator( bool log = false) : Log( log) {}
 
-    virtual Trap run( const std::string& tr, uint64 instrs_to_run) = 0;
-    Trap run_no_limit( const std::string& tr) { return run( tr, MAX_VAL64); }
+    virtual Trap run( uint64 instrs_to_run) = 0;
     virtual void set_target( const Target& target) = 0;
+    virtual void set_memory( FuncMemory* m) = 0;
+    virtual void init_checker() = 0;
+
+    Trap run_no_limit() { return run( MAX_VAL64); }
 
     static std::unique_ptr<Simulator> create_simulator( const std::string& isa, bool functional_only, bool log);
     static std::unique_ptr<Simulator> create_configured_simulator();


### PR DESCRIPTION
The initial decision to keep FuncMemory owned by Simulator was wrong, as
memory is not a part of CPU, it is an same-rank agent. In addition, we
have a third agent as well - ELF loader, and soon we would have GDB as
another agent, and so on.