### PR TITLE
Move startPC out of FuncMemory

### DIFF
--- a/simulator/func_sim/func_sim.cpp
+++ b/simulator/func_sim/func_sim.cpp
@@ -63,16 +63,9 @@ typename FuncSim<ISA>::FuncInstr FuncSim<ISA>::step()
 }
 
 template <typename ISA>
-void FuncSim<ISA>::init()
-{
-    PC = mem->startPC();
-    nops_in_a_row = 0;
-}
-
-template <typename ISA>
 Trap FuncSim<ISA>::run( uint64 instrs_to_run)
 {
-    init();
+    nops_in_a_row = 0;
     for ( uint32 i = 0; i < instrs_to_run; ++i) {
         const auto& instr = step();
         sout << instr << std::endl;

--- a/simulator/func_sim/func_sim.h
+++ b/simulator/func_sim/func_sim.h
@@ -41,7 +41,6 @@ class FuncSim : public Simulator
         explicit FuncSim( bool log = false);
 
         void set_memory( FuncMemory* memory) final;
-        void init();
         void init_checker() final { };
         FuncInstr step();
         Trap run(uint64 instrs_to_run) final;

--- a/simulator/func_sim/t/unit_test.cpp
+++ b/simulator/func_sim/t/unit_test.cpp
@@ -18,6 +18,20 @@
 static const std::string valid_elf_file = TEST_PATH "/tt.core32.out";
 static const std::string smc_code = TEST_PATH "/smc.out";
 
+TEST_CASE( "Process_Wrong_Args_Of_Constr: Func_Sim_init")
+{
+    // Just call a constructor
+    CHECK_NOTHROW( FuncSim<MIPS32>() );
+}
+
+TEST_CASE( "FuncSim: create empty memory and get lost")
+{
+    auto m = FuncMemory::create_hierarchied_memory();
+    FuncSim<MIPS32> sim( false);
+    sim.set_memory( m.get());
+    CHECK_THROWS_AS( sim.run_no_limit(), BearingLost);
+}
+
 // TODO: remove that class, use true FuncSim interfaces instead
 template <typename ISA>
 struct FuncSimAndMemory : FuncSim<ISA>
@@ -46,11 +60,17 @@ struct FuncSimAndMemory : FuncSim<ISA>
     }
 };
 
-TEST_CASE( "Process_Wrong_Args_Of_Constr: Func_Sim_init")
+TEST_CASE( "FuncSim: get lost without pc")
 {
-    // Just call a constructor
-    CHECK_NOTHROW( FuncSim<MIPS32>() );
+    auto m = FuncMemory::create_hierarchied_memory();
+    FuncSim<MIPS32> sim( false);
+    sim.set_memory( m.get());
+    ElfLoader( valid_elf_file).load_to( m.get());
+    CHECK_THROWS_AS( sim.run_no_limit(), BearingLost);
+}
 
+TEST_CASE( "Process_Wrong_Args_Of_Constr: Func_Sim_init_and_load")
+{
     // Call constructor and init
     CHECK_NOTHROW( FuncSimAndMemory<MIPS32>().init_trace( valid_elf_file) );
 }

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -17,12 +17,14 @@ namespace config {
 
 int main( int argc, const char* argv[]) try {
     config::handleArgs( argc, argv, 1);
+    ElfLoader elf( config::binary_filename);
     auto memory = FuncMemory::create_hierarchied_memory();
-    ::load_elf_file( memory.get(), config::binary_filename);
+    elf.load_to( memory.get());
 
     auto sim = Simulator::create_configured_simulator();
     sim->set_memory( memory.get());
     sim->init_checker();
+    sim->set_pc( elf.get_startPC());
     sim->run( config::num_steps);
     return 0;
 }

--- a/simulator/memory/elf/elf_loader.h
+++ b/simulator/memory/elf/elf_loader.h
@@ -10,6 +10,7 @@
 #include <infra/exception.h>
 #include <infra/types.h>
 
+#include <memory>
 #include <string>
 
 struct InvalidElfFile final : Exception
@@ -21,6 +22,27 @@ struct InvalidElfFile final : Exception
 
 class FuncMemory;
 
-void load_elf_file(FuncMemory* memory, const std::string& filename, AddrDiff offset = 0);
+namespace ELFIO {
+    class elfio;
+} // namespace ELFIO
 
+class ElfLoader
+{
+public:
+    explicit ElfLoader( const std::string& filename, AddrDiff offset = 0);
+    ~ElfLoader();
+
+    // Regardless of 'const std::unique_ptr', we delete everything explicitly
+    ElfLoader( const ElfLoader&) = delete;
+    ElfLoader( ElfLoader&&) = delete;
+    ElfLoader& operator=( const ElfLoader&) = delete;
+    ElfLoader& operator=( ElfLoader&&) = delete;
+
+    void load_to(FuncMemory* memory) const;
+    Addr get_startPC() const;
+private:
+    const std::unique_ptr<ELFIO::elfio> reader;
+    AddrDiff offset;
+};
+   
 #endif

--- a/simulator/memory/hierarchied_memory.cpp
+++ b/simulator/memory/hierarchied_memory.cpp
@@ -144,7 +144,6 @@ bool HierarchiedMemory::check( Addr addr) const
 
 void HierarchiedMemory::duplicate_to( FuncMemory* target) const
 {
-    target->set_startPC( startPC());
     for ( auto set_it = memory.begin(); set_it != memory.end(); ++set_it)
         for ( auto page_it = set_it->begin(); page_it != set_it->end(); ++page_it)
             target->memcpy_host_to_guest( get_addr( set_it, page_it, page_it->begin()),

--- a/simulator/memory/memory.h
+++ b/simulator/memory/memory.h
@@ -36,9 +36,6 @@ class FuncMemory
 	static std::unique_ptr<FuncMemory>
 	    create_plain_memory( uint32 addr_bits = 20);
 
-        Addr startPC() const { return startPC_addr; }
-        void set_startPC(Addr value) { startPC_addr = value; }
-
         virtual size_t memcpy_host_to_guest( Addr dst, const Byte* src, size_t size) = 0;
         virtual size_t memcpy_guest_to_host( Byte* dst, Addr src, size_t size) const = 0;
         virtual void duplicate_to( FuncMemory* target) const = 0;
@@ -66,7 +63,6 @@ class FuncMemory
         FuncMemory& operator=( const FuncMemory&) = default;
         FuncMemory& operator=( FuncMemory&&) = default;
     private:
-        Addr startPC_addr = 0;
         template<typename Instr> void load( Instr* instr) const;
         template<typename Instr> void store( const Instr& instr);
 };

--- a/simulator/modules/core/perf_sim.cpp
+++ b/simulator/modules/core/perf_sim.cpp
@@ -49,8 +49,6 @@ Trap PerfSim<ISA>::run( uint64 instrs_to_run)
 
     writeback.set_instrs_to_run( instrs_to_run);
 
-    set_target( Target( memory->startPC(), 0));
-
     start_time = std::chrono::high_resolution_clock::now();
 
     while (!is_halt())

--- a/simulator/modules/core/t/unit_test.cpp
+++ b/simulator/modules/core/t/unit_test.cpp
@@ -16,6 +16,14 @@
 static const std::string valid_elf_file = TEST_PATH "/tt.core32.out";
 static const std::string smc_code = TEST_PATH "/smc.out";
 
+TEST_CASE( "PerfSim: create empty memory and get lost")
+{
+    auto m = FuncMemory::create_hierarchied_memory();
+    PerfSim<MIPS32> sim( false);
+    sim.set_memory( m.get());
+    CHECK_THROWS_AS( sim.run_no_limit(), Deadlock);
+}
+
 // TODO: remove that class, use true FuncSim interfaces instead
 template <typename ISA>
 struct PerfSimAndMemory : PerfSim<ISA>

--- a/simulator/modules/core/t/unit_test.cpp
+++ b/simulator/modules/core/t/unit_test.cpp
@@ -27,15 +27,20 @@ struct PerfSimAndMemory : PerfSim<ISA>
        this->set_memory( mem.get());
     }
 
-    auto run_trace( const std::string& tr, uint64 steps) {
-        ::load_elf_file( mem.get(), tr);
+    void init_trace( const std::string& tr) {
+        ElfLoader elf( tr);
+        elf.load_to( mem.get());
         this->init_checker();
+        this->set_pc( elf.get_startPC());
+    }
+
+    auto run_trace( const std::string& tr, uint64 steps) {
+        init_trace( tr);
         return PerfSim<ISA>::run( steps);
     }
 
     auto run_trace_no_limit( const std::string& tr) {
-        ::load_elf_file( mem.get(), tr);
-        this->init_checker();
+        init_trace( tr);
         return PerfSim<ISA>::run_no_limit();
     }
 };
@@ -75,8 +80,10 @@ TEST_CASE( "Perf_Sim: Run_SMC_Trace_WithoutChecker")
 {
     PerfSim<MIPS32> sim( false);
     auto mem = FuncMemory::create_hierarchied_memory();
-    ::load_elf_file( mem.get(), smc_code);
     sim.set_memory( mem.get());
+    ElfLoader elf( smc_code);
+    elf.load_to( mem.get());
+    sim.set_pc( elf.get_startPC());
     CHECK( sim.run_no_limit( ) == Trap::NO_TRAP);
 }
 

--- a/simulator/simulator.h
+++ b/simulator/simulator.h
@@ -23,6 +23,7 @@ public:
     virtual void init_checker() = 0;
 
     Trap run_no_limit() { return run( MAX_VAL64); }
+    void set_pc( Addr pc) { set_target( Target( pc, 0)); }
 
     static std::unique_ptr<Simulator> create_simulator( const std::string& isa, bool functional_only, bool log);
     static std::unique_ptr<Simulator> create_configured_simulator();


### PR DESCRIPTION
Finally, we may move a starting PC value out of FuncMemory, as it is
something we define in uarch specialization rather then in the memory.

We have to convert our ELF loader to class, so it can do both loading to
FuncMemory and providing a PC value as address of the '.text' section.