### PR TITLE
Remove redundant ownership of FuncMemory

### DIFF
--- a/simulator/func_sim/func_sim.cpp
+++ b/simulator/func_sim/func_sim.cpp
@@ -11,8 +11,8 @@ FuncSim<ISA>::FuncSim( bool log) : Simulator( log) { }
 template <typename ISA>
 void FuncSim<ISA>::set_memory( std::shared_ptr<FuncMemory> m)
 {
-    mem = m;
-    imem.set_memory( m);
+    mem = std::move( m);
+    imem.set_memory( mem);
 }
 
 template <typename ISA>

--- a/simulator/func_sim/instr_memory.h
+++ b/simulator/func_sim/instr_memory.h
@@ -16,7 +16,7 @@ class InstrMemory
 {
     std::shared_ptr<FuncMemory> mem;
 public:
-    void set_memory( std::shared_ptr<FuncMemory> m) { mem = m; }
+    void set_memory( std::shared_ptr<FuncMemory> m) { mem = std::move( m); }
     auto fetch( Addr pc) const { return mem->read<uint32, Instr::endian>( pc); }
     auto fetch_instr( Addr PC) { return Instr( fetch( PC), PC); }
 };

--- a/simulator/interface/cen64/cen64_intf.cpp
+++ b/simulator/interface/cen64/cen64_intf.cpp
@@ -8,19 +8,17 @@
 #include <memory/memory.h>
 #include <simulator.h>
 
-extern std::shared_ptr<FuncMemory> generate_cen64_memory( bus_controller * bus_ptr);
+extern std::shared_ptr<FuncMemory> generate_cen64_memory( bus_controller* bus_ptr);
 
 struct vr4300
 {
     std::shared_ptr<CycleAccurateSimulator> sim;
-    std::shared_ptr<FuncMemory> bus;
 
-    int init( struct bus_controller * bus_ptr)
+    int init( struct bus_controller* bus_ptr)
     {
-        sim = CycleAccurateSimulator::create_simulator("mips64", true);
-        bus = generate_cen64_memory( bus_ptr);
-        sim->set_memory( bus);
-        sim->set_pc(0x1fc00000ull);
+        sim = CycleAccurateSimulator::create_simulator( "mips64", true);
+        sim->set_memory( generate_cen64_memory( bus_ptr));
+        sim->set_pc( 0x1fc00000ull);
         return 0;
     }
 };

--- a/simulator/main.cpp
+++ b/simulator/main.cpp
@@ -22,7 +22,7 @@ int main( int argc, const char* argv[]) try {
     elf.load_to( memory.get());
 
     auto sim = Simulator::create_configured_simulator();
-    sim->set_memory( memory);
+    sim->set_memory( std::move( memory));
     sim->init_checker();
     sim->set_pc( elf.get_startPC());
     sim->run( config::num_steps);

--- a/simulator/modules/fetch/fetch.h
+++ b/simulator/modules/fetch/fetch.h
@@ -22,7 +22,7 @@ class Fetch : public Log
 public:
     explicit Fetch( bool log);
     void clock( Cycle cycle);
-    void set_memory( std::shared_ptr<FuncMemory> mem) { memory.set_memory( mem); }
+    void set_memory( std::shared_ptr<FuncMemory> mem) { memory.set_memory( std::move( mem)); }
 
 private:
     InstrMemoryCached<FuncInstr> memory;

--- a/simulator/modules/mem/mem.h
+++ b/simulator/modules/mem/mem.h
@@ -41,7 +41,7 @@ class Mem : public Log
     public:
         explicit Mem( bool log);
         void clock( Cycle cycle);
-        void set_memory( std::shared_ptr<FuncMemory> mem) { memory = mem; }
+        void set_memory( std::shared_ptr<FuncMemory> mem) { memory = std::move( mem); }
 };
 
 

--- a/simulator/modules/writeback/writeback.cpp
+++ b/simulator/modules/writeback/writeback.cpp
@@ -15,10 +15,10 @@ Writeback<ISA>::Writeback(bool log) : Log( log)
 template <typename ISA>
 void Writeback<ISA>::Checker::init( const FuncMemory& outer_mem)
 {
+    auto memory = FuncMemory::create_hierarchied_memory();
     sim = std::make_shared<FuncSim<ISA>>();
-    memory = FuncMemory::create_hierarchied_memory();
     outer_mem.duplicate_to( memory);
-    sim->set_memory( memory);
+    sim->set_memory( std::move( memory));
     active = true;
 }
 

--- a/simulator/modules/writeback/writeback.h
+++ b/simulator/modules/writeback/writeback.h
@@ -39,7 +39,6 @@ private:
 
     class Checker {
         std::shared_ptr<FuncSim<ISA>> sim;
-        std::shared_ptr<FuncMemory> memory;
         bool active = false;
     public:
         void check( const FuncInstr& instr);


### PR DESCRIPTION
Previously we had to keep a 'master' std::unique_ptr's which does
the deletion of FuncMemory. Now, as we have shared ownership between
Simulator and other instances, we do not need them any longer.

As a bonus, I put std::move whenever it may be used, so we won't change
reference counters while passing std::shared_ptr through the hierarchy.