### PR TITLE
Switch GDB back to master revision until GDB 8.3 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
         sudo apt-get install binutils-mips-linux-gnu --allow-unauthenticated
     fi
 # Download GDB
-  - git clone --depth=1 https://github.com/bminor/binutils-gdb.git --single-branch --branch binutils-2_32-branch
+  - git clone --depth=1 https://github.com/bminor/binutils-gdb.git --single-branch --branch master
 
 before_script:
   - cd $TRAVIS_BUILD_DIR/traces            && make tt


### PR DESCRIPTION
We need to track that GDB 8.3 will not contain build bugs.