### PR TITLE
Attempt integrating always hit and infinite cache models

### DIFF
--- a/simulator/infra/cache/cache_tag_array.h
+++ b/simulator/infra/cache/cache_tag_array.h
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-// Replacement algorithm modules (LRU)
+// Replacement algorithm module (LRU)
 
 class ReplacementModule
 {
@@ -50,8 +50,8 @@ class CacheTagArraySizeCheck : public Log
             uint32 addr_size_in_bits
         );
 
-        const uint32 size_in_bytes;
-        const uint32 ways;
+        uint32 size_in_bytes;
+        uint32 ways;
         const uint32 line_size;
         const uint32 addr_size_in_bits;
 };
@@ -67,7 +67,7 @@ class CacheTagArraySize : public CacheTagArraySizeCheck
         );
         const size_t line_bits;
     public:
-        const uint32 sets;
+        uint32 sets;
         const size_t set_bits;
         const Addr   addr_mask;
 
@@ -86,18 +86,19 @@ class CacheTagArray : public CacheTagArraySize
             uint32 size_in_bytes,
             uint32 ways,
             uint32 line_size,
-            uint32 addr_size_in_bits = 32
+            uint32 addr_size_in_bits = 32,
+            bool replacement_module_generation = true
         );
 
         // hit or not
-        bool lookup( Addr addr) { return read( addr).first; }
+        virtual bool lookup( Addr addr) { return read( addr).first; }
+        // create new entry in cache
+        virtual Way write( Addr addr);
         // lookup the cache and update LRU info
-        std::pair<bool, Way> read( Addr addr);
+        virtual std::pair<bool, Way> read( Addr addr);
         // find in the cache but do not update LRU info
         std::pair<bool, Way> read_no_touch( Addr addr) const;
-        // create new entry in cache
-        Way write( Addr addr);
-    private:
+    protected:
         struct Tag
         {
             bool is_valid = false;
@@ -110,7 +111,46 @@ class CacheTagArray : public CacheTagArraySize
         // hash tabe to lookup tags in O(1)
         std::vector<google::dense_hash_map<Addr, Way>> lookup_helper;
         const uint32 impossible_key = INT32_MAX;
-        ReplacementModule replacement_module; // LRU algorithm module
+        std::unique_ptr<ReplacementModule> replacement_module = nullptr;
 };
+
+class AlwaysHitCacheTagArray : public CacheTagArray
+{
+    public:
+        AlwaysHitCacheTagArray(
+                uint32 size_in_bytes,
+                uint32 ways,
+                uint32 line_size,
+                uint32 addr_size_in_bits = 32
+        );
+
+        bool lookup( Addr /* unused */) override { return true; }
+};
+
+class InfiniteCacheTagArray : public CacheTagArray
+{
+    public:
+        InfiniteCacheTagArray(
+                uint32 size_in_bytes,
+                uint32 ways,
+                uint32 line_size,
+                uint32 addr_size_in_bits = 32
+        );
+
+        Way write( Addr addr) override;
+        // Since it's not permitted to these interfaces, we have to keep both methods
+        // even thow touch concept is pointless in the infinite cache model
+        std::pair<bool, Way> read( Addr addr) override { return read_no_touch( addr); }
+    private:
+        void double_size();
+        std::vector<Way> way_counter;
+};
+
+std::unique_ptr<CacheTagArray> create_cache_tag_array(
+    uint32 size_in_bytes,
+    uint32 ways,
+    uint32 line_size,
+    uint32 addr_size_in_bits = 32,
+    const std::string& cache_tag_array_type = "always_hit"); //should be default for normal behaviour
 
 #endif // CACHE_TAG_ARRAY_H

--- a/simulator/infra/replacement/cache_replacement.cpp
+++ b/simulator/infra/replacement/cache_replacement.cpp
@@ -131,7 +131,7 @@ void PseudoLRU::construct_tree( core::tree<LRU_tree_node>::iterator LRU_tree_nod
     }
 }
 
-std::size_t PseudoLRU::which_sibling( core::tree<LRU_tree_node>::iterator LRU_tree_node_it) //tree container doesnt provide such an option
+std::size_t PseudoLRU::which_sibling( core::tree<LRU_tree_node>::iterator LRU_tree_node_it) //tree container doesnt provide such option
 {
     return LRU_tree_node_it.data().way_number % 2 == 0 ? Left : Right;
 }

--- a/simulator/modules/fetch/bpu/bpu.cpp
+++ b/simulator/modules/fetch/bpu/bpu.cpp
@@ -27,25 +27,23 @@ class BP final: public BaseBP
 {
     std::vector<std::vector<T>> directions;
     std::vector<std::vector<Addr>> targets;
-    CacheTagArray tags;
+    std::unique_ptr<CacheTagArray> tags = nullptr;
 
     bool is_way_taken( size_t way, Addr PC, Addr target) const
     {
-        return directions[ way][ tags.set(PC)].is_taken( PC, target);
+        return directions[ way][ tags->set(PC)].is_taken( PC, target);
     }
 public:
     BP( uint32 size_in_entries, uint32 ways, uint32 branch_ip_size_in_bits) try
         : directions( ways, std::vector<T>( size_in_entries / ways))
         , targets( ways, std::vector<Addr>( size_in_entries / ways))
-        , tags( size_in_entries,
-            ways,
-            // we're reusing existing CacheTagArray functionality,
-            // but here we don't split memory in blocks, storing
-            // IP's only, so hardcoding here the granularity of 4 bytes:
-            4,
-            branch_ip_size_in_bits)
     {
+        // we're reusing existing CacheTagArray functionality,
+        // but here we don't split memory in blocks, storing
+        // IP's only, so hardcoding here the granularity of 4 bytes:
+        tags = create_cache_tag_array( size_in_entries, ways, 4, branch_ip_size_in_bits);
     }
+
     catch (const CacheTagArrayInvalidSizeException& e) {
         throw BPInvalidMode(e.what());
     }
@@ -54,27 +52,27 @@ public:
     bool is_taken( Addr PC) const final
     {
         // do not update LRU information on prediction,
-        // so "no_touch" version of "tags.read" is used:
-        const auto[ is_hit, way] = tags.read_no_touch( PC);
-        return is_hit && is_way_taken( way, PC, targets[ way][ tags.set(PC)]);
+        // so "no_touch" version of "tags->read" is used:
+        const auto[ is_hit, way] = tags->read_no_touch( PC);
+        return is_hit && is_way_taken( way, PC, targets[ way][ tags->set(PC)]);
     }
 
     bool is_hit( Addr PC) const final
     {
         // do not update LRU information on this check,
-        // so "no_touch" version of "tags.read" is used:
-        return tags.read_no_touch( PC).first;
+        // so "no_touch" version of "tags->read" is used:
+        return tags->read_no_touch( PC).first;
     }
 
     Addr get_target( Addr PC) const final
     {
         // do not update LRU information on prediction,
-        // so "no_touch" version of "tags.read" is used:
-        const auto[ is_hit, way] = tags.read_no_touch( PC);
+        // so "no_touch" version of "tags->read" is used:
+        const auto[ is_hit, way] = tags->read_no_touch( PC);
 
         // return saved target only in case it is predicted taken
-        if ( is_hit && is_way_taken( way, PC, targets[ way][ tags.set(PC)]))
-            return targets[ way][ tags.set(PC)];
+        if ( is_hit && is_way_taken( way, PC, targets[ way][ tags->set(PC)]))
+            return targets[ way][ tags->set(PC)];
 
         return PC + 4;
     }
@@ -82,11 +80,11 @@ public:
     /* update */
     void update( const BPInterface& bp_upd) final
     {
-        const auto set = tags.set( bp_upd.pc);
-        auto[ is_hit, way] = tags.read( bp_upd.pc);
+        const auto set = tags->set( bp_upd.pc);
+        auto[ is_hit, way] = tags->read( bp_upd.pc);
 
         if ( !is_hit) { // miss
-            way = tags.write( bp_upd.pc); // add new entry to cache
+            way = tags->write( bp_upd.pc); // add new entry to cache
             auto& entry = directions[ way][ set];
             entry.reset();
         }

--- a/simulator/modules/fetch/bpu/t/unit_test.cpp
+++ b/simulator/modules/fetch/bpu/t/unit_test.cpp
@@ -72,7 +72,7 @@ TEST_CASE( "One bit predictor")
 
     Addr PC = 28;
     Addr target = 12;
-    
+
     bp->update( BPInterface( PC, true, target, false));
     CHECK( bp->is_taken(PC) );
     CHECK( bp->get_target(PC) == target);
@@ -84,8 +84,8 @@ TEST_CASE( "One bit predictor in case of changed target")
 
     Addr PC = 28;
     Addr target = 12;
- 
-    //learn   
+
+    //learn
     bp->update( BPInterface( PC, true, target, false));
     //change the target
     target = 16;
@@ -99,7 +99,7 @@ TEST_CASE( "Two bit predictor, basic")
 
     Addr PC = 28;
     Addr target = 12;
-    
+
     bp->update( BPInterface( PC, true, target, false));
     CHECK( bp->is_taken(PC) );
     CHECK( bp->get_target(PC) == target);

--- a/simulator/modules/fetch/fetch.cpp
+++ b/simulator/modules/fetch/fetch.cpp
@@ -43,9 +43,7 @@ Fetch<FuncInstr>::Fetch(bool log) : Log( log)
     rp_flush_target_from_decode = make_read_port<Target>("DECODE_2_FETCH_TARGET", PORT_LATENCY);
 
     bp = BaseBP::create_configured_bp();
-    tags = std::make_unique<CacheTagArray>( config::instruction_cache_size,
-                                            config::instruction_cache_ways,
-                                            config::instruction_cache_line_size);
+    tags = create_cache_tag_array( config::instruction_cache_size, config::instruction_cache_ways, config::instruction_cache_line_size);
 }
 
 template <typename FuncInstr>


### PR DESCRIPTION
Always hit model seems to be working right ( number of cycles significantly drops). I have only modified `lookup` method, since as I discovered performance is stalled only after it returns false ( I am not sure if this is all, I had to do).

Also I have troubles with the infinite cache module. I've decided to double up the `CacheTagArray` size every time it overflows. The problem is that the `BPU` is reusing `CacheTagArray` functionality so `BP::directions` and `BP::targets` vectors should also be resized after the `CacheTagArray` does. Changing the returned value of the  `CacheTagArray::write` method to smth like std::pair<Way way, bool was_cache_resize> could be an obvious solution, but this doesn't seem right, since it will change the `CacheTagArray` interface. ( Also the fact, that `CacheTagArraySizeCheck::size_in_bytes` and `CacheTagArraySizeCheck::ways` are not longer constant, feels wrong either)

And finally, since `CacheTagArray` is being tested by the several unit-test modules, I have no clues, how the new tests should look like.

I've just realized, that today is the last day of simulator tasks, so I will try to answer ASAP.