### PR TITLE
Provide 'deleted key' to DenseHashMap

### DIFF
--- a/simulator/func_sim/instr_memory.h
+++ b/simulator/func_sim/instr_memory.h
@@ -54,7 +54,7 @@ template<typename ISA>
 class InstrMemoryCached : public InstrMemory<ISA>
 {
     using Instr = typename ISA::FuncInstr;
-    InstrCache<Addr, Instr, INSTR_CACHE_CAPACITY, 0x0> instr_cache{};
+    InstrCache<Addr, Instr, INSTR_CACHE_CAPACITY, 0x0, all_ones<Addr>()> instr_cache{};
 public:
     explicit InstrMemoryCached( Endian endian) : InstrMemory<ISA>( endian) { }
     Instr fetch_instr( Addr PC) final
@@ -68,7 +68,8 @@ public:
             instr_cache.erase( PC);
 
         auto instr = InstrMemory<ISA>::fetch_instr( PC);
-        instr_cache.update( PC, instr);
+        if ( PC != 0)
+            instr_cache.update( PC, instr);
         return instr;
     }
 };

--- a/simulator/infra/instrcache/instr_cache.h
+++ b/simulator/infra/instrcache/instr_cache.h
@@ -16,13 +16,14 @@
 #include <utility>
 #include <vector>
 
-template <typename Key, typename Value, size_t CAPACITY, Key INVALID_KEY = 0>
+template <typename Key, typename Value, size_t CAPACITY, Key INVALID_KEY, Key DELETED_KEY>
 class InstrCache
 {
     public:
         InstrCache() : pointers( CAPACITY)
         {
             pointers.set_empty_key( INVALID_KEY);
+            pointers.set_deleted_key( DELETED_KEY);
             lru_module = create_cache_replacement( "LRU", CAPACITY);
             // Touch everything to initialize order
             for (size_t i = 0; i < CAPACITY; ++i)

--- a/simulator/infra/instrcache/t/unit_test.cpp
+++ b/simulator/infra/instrcache/t/unit_test.cpp
@@ -97,7 +97,7 @@ TEST_CASE( "exceed_capacity_and_test_lru: Add_More_Elements_Than_Capacity_And_Ch
 {
     constexpr const auto CAPACITY = 8192u;
 
-    InstrCache<std::size_t, Dummy, CAPACITY, 0, all_ones<Addr>()> cache;
+    InstrCache<std::size_t, Dummy, CAPACITY, 0, all_ones<std::size_t>()> cache;
     for ( std::size_t i = 1; i <= CAPACITY; ++i) // note the <=
         cache.update( i, Dummy( i, i));
 

--- a/simulator/infra/instrcache/t/unit_test.cpp
+++ b/simulator/infra/instrcache/t/unit_test.cpp
@@ -8,6 +8,7 @@
 // Modules
 #include "../instr_cache.h"
 
+#include <infra/macro.h>
 #include <infra/types.h>
 
 class Dummy {
@@ -21,7 +22,7 @@ public:
 
 TEST_CASE( "update_and_find_int: Update_Find_And_Check_Using_Int")
 {
-    InstrCache<Addr, Dummy, 8192> cache{};
+    InstrCache<Addr, Dummy, 8192, 0, all_ones<Addr>()> cache{};
 
     const Addr PC = 0x401c04;
     const Dummy test_number( 0x103abf9, 0x401c04);
@@ -35,11 +36,11 @@ TEST_CASE( "update_and_find_int: Update_Find_And_Check_Using_Int")
 
 TEST_CASE( "check_method_size: Check_Method_Size")
 {
-    InstrCache<Addr, Dummy, 8192> instr_cache{};
+    InstrCache<Addr, Dummy, 8192, 0, all_ones<Addr>()> instr_cache{};
 
     uint32 instr_bytes = 0x2484ae10;
     Addr PC = 0x30ae17;
-    const std::size_t SIZE = InstrCache<Addr, Dummy, 8192>::get_capacity() / 12;
+    const std::size_t SIZE = instr_cache.get_capacity() / 12;
 
     for ( std::size_t i = 0; i < SIZE; ++i)
     {
@@ -54,7 +55,7 @@ TEST_CASE( "check_method_size: Check_Method_Size")
 
 TEST_CASE( "update_and_find: Update_Find_And_Check")
 {
-    InstrCache<Addr, Dummy, 8192> instr_cache{};
+    InstrCache<Addr, Dummy, 8192, 0, all_ones<Addr>()> instr_cache{};
 
     const uint32 instr_bytes = 0x3c010400;
     const Addr PC = 0x401c04;
@@ -66,7 +67,7 @@ TEST_CASE( "update_and_find: Update_Find_And_Check")
 
 TEST_CASE( "check_method_erase: Check_Method_Erase")
 {
-    InstrCache<Addr, Dummy, 8192> instr_cache{};
+    InstrCache<Addr, Dummy, 8192, 0, all_ones<Addr>()> instr_cache{};
 
     const uint32 instr_bytes = 0x3c010400;
     const Addr PC = 0x401c04;
@@ -80,7 +81,7 @@ TEST_CASE( "check_method_erase: Check_Method_Erase")
 
 TEST_CASE( "check_method_empty: Check_Method_Empty")
 {
-    InstrCache<Addr, Dummy, 8192> instr_cache{};
+    InstrCache<Addr, Dummy, 8192, 0, all_ones<Addr>()> instr_cache{};
 
     const uint32 instr_bytes = 0x2484ae10;
     const Addr PC = 0x400d05;
@@ -96,7 +97,7 @@ TEST_CASE( "exceed_capacity_and_test_lru: Add_More_Elements_Than_Capacity_And_Ch
 {
     constexpr const auto CAPACITY = 8192u;
 
-    InstrCache<std::size_t, Dummy, CAPACITY> cache;
+    InstrCache<std::size_t, Dummy, CAPACITY, 0, all_ones<Addr>()> cache;
     for ( std::size_t i = 1; i <= CAPACITY; ++i) // note the <=
         cache.update( i, Dummy( i, i));
 

--- a/simulator/mips/mips_instr.h
+++ b/simulator/mips/mips_instr.h
@@ -22,7 +22,7 @@
 template<typename I>
 struct MIPSTableEntry;
 
-template <typename Key, typename Value, size_t CAPACITY, Key INVALID_KEY>
+template <typename Key, typename Value, size_t CAPACITY, Key INVALID_KEY, Key DELETED_KEY>
 class InstrCache;
 
 template<typename R>
@@ -61,7 +61,7 @@ class BaseMIPSInstr : public BaseInstruction<R, MIPSRegister>
         }
     private:
         using MyDatapath = typename BaseInstruction<R, MIPSRegister>::MyDatapath;
-        using DisasmCache = InstrCache<uint32, std::string, 8192, all_ones<uint32>()>;
+        using DisasmCache = InstrCache<uint32, std::string, 8192, all_ones<uint32>(), all_ones<uint32>() - 1>;
 
         const uint32 raw;
         const bool raw_valid = false;


### PR DESCRIPTION
DenseHashMap operation requires a special 'deleted key' to support element erasure
Found with assertion failures in debug build.