### PR TITLE
Do not fix fanout at WritePort construction

### DIFF
--- a/simulator/infra/ports/ports.cpp
+++ b/simulator/infra/ports/ports.cpp
@@ -65,8 +65,8 @@ BasicReadPort::BasicReadPort( const std::shared_ptr<PortMap>& port_map, const st
     get_port_map()->add_port( this);
 }
 
-BasicWritePort::BasicWritePort( const std::shared_ptr<PortMap>& port_map, const std::string& key, uint32 bandwidth, uint32 fanout) :
-    Port( port_map, key), _fanout(fanout), installed_bandwidth(bandwidth)
+BasicWritePort::BasicWritePort( const std::shared_ptr<PortMap>& port_map, const std::string& key, uint32 bandwidth) :
+    Port( port_map, key), installed_bandwidth(bandwidth)
 {
     get_port_map()->add_port( this);
 }
@@ -75,10 +75,7 @@ void BasicWritePort::base_init( const std::vector<BasicReadPort*>& readers)
 {
     if ( readers.empty())
         throw PortError( get_key() + " has no ReadPorts");
-    if ( readers.size() > _fanout)
-        throw PortError( get_key() + " WritePort is overloaded by fanout");
-    if ( readers.size() != _fanout)
-        throw PortError( get_key() + " WritePort is underloaded by fanout");
+    _fanout = readers.size();
 
     initialized_bandwidth = installed_bandwidth;
 }

--- a/simulator/infra/ports/ports.h
+++ b/simulator/infra/ports/ports.h
@@ -95,7 +95,7 @@ public:
     auto get_bandwidth() const noexcept { return initialized_bandwidth; }
 
 protected:
-    BasicWritePort( const std::shared_ptr<PortMap>& port_map, const std::string& key, uint32 bandwidth, uint32 fanout);
+    BasicWritePort( const std::shared_ptr<PortMap>& port_map, const std::string& key, uint32 bandwidth);
     void base_init( const std::vector<BasicReadPort*>& readers);
 
     void increment_write_counter( Cycle cycle)
@@ -112,8 +112,8 @@ private:
 
     uint32 write_counter = 0;
     uint32 initialized_bandwidth = 0;
-
-    const uint32 _fanout = 0;
+    uint32 _fanout = 0;
+    
     const uint32 installed_bandwidth = 0;
 };
 
@@ -122,8 +122,8 @@ template<class T> class ReadPort;
 template<class T> class WritePort : public BasicWritePort
 {
 public:
-    WritePort<T>( const std::shared_ptr<PortMap>& port_map, const std::string& key, uint32 bandwidth, uint32 fanout)
-        : BasicWritePort( port_map, key, bandwidth, fanout)
+    WritePort<T>( const std::shared_ptr<PortMap>& port_map, const std::string& key, uint32 bandwidth)
+        : BasicWritePort( port_map, key, bandwidth)
     { }
 
     void write( T&& what, Cycle cycle)

--- a/simulator/infra/ports/ports.h
+++ b/simulator/infra/ports/ports.h
@@ -112,7 +112,7 @@ private:
 
     uint32 write_counter = 0;
     uint32 initialized_bandwidth = 0;
-    uint32 _fanout = 0;
+    std::size_t _fanout = 0;
     
     const uint32 installed_bandwidth = 0;
 };

--- a/simulator/infra/ports/t/example_test.cpp
+++ b/simulator/infra/ports/t/example_test.cpp
@@ -50,10 +50,10 @@ class A
 {
 public:
     explicit A( const std::shared_ptr<PortMap>& map)
-        : to_B( map, "A_to_B", PORT_BW, PORT_FANOUT)
+        : to_B( map, "A_to_B", PORT_BW)
         , from_B( map, "B_to_A", PORT_LATENCY)
         , init( map, "init_A", PORT_LATENCY)
-        , stop( map, "stop", PORT_BW, PORT_FANOUT)
+        , stop( map, "stop", PORT_BW)
     { }
 
     void clock( Cycle cycle)
@@ -94,7 +94,7 @@ class B
 {
 public:
     explicit B( const std::shared_ptr<PortMap>& map)
-        : to_A( map, "B_to_A", PORT_BW, PORT_FANOUT)
+        : to_A( map, "B_to_A", PORT_BW)
         , from_A( map, "A_to_B", PORT_LATENCY)
     { };
 
@@ -127,7 +127,7 @@ TEST_CASE( "test_ports: Test_Ports_A_B")
     A a( map);
     B b( map);
 
-    WritePort<int> init( map, "init_A", PORT_BW, PORT_FANOUT);
+    WritePort<int> init( map, "init_A", PORT_BW);
     ReadPort<bool> stop( map, "stop", PORT_LATENCY);
 
     map->init();

--- a/simulator/infra/ports/t/unit_test.cpp
+++ b/simulator/infra/ports/t/unit_test.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Ports: no write port")
 TEST_CASE("Ports: no read port")
 {
     auto pm = PortMap::create_port_map();
-    WritePort<int> output( pm, "Yek", PORT_BW, PORT_FANOUT);
+    WritePort<int> output( pm, "Yek", PORT_BW);
     CHECK_THROWS_AS( pm->init(), PortError);
 }
 
@@ -26,32 +26,15 @@ TEST_CASE("Ports: two write ports")
 {
     auto pm = PortMap::create_port_map();
     ReadPort<int> input( pm, "Key", PORT_LATENCY);
-    WritePort<int> output( pm, "Key", PORT_BW, PORT_FANOUT);
-    CHECK_THROWS_AS( WritePort<int>( pm, "Key", PORT_BW, PORT_FANOUT), PortError);
-}
-
-TEST_CASE("Ports: fanout overload")
-{
-    auto pm = PortMap::create_port_map();
-    ReadPort<int> input( pm, "Key", PORT_LATENCY);
-    WritePort<int> output( pm, "Key", PORT_BW, PORT_FANOUT);
-    ReadPort<int> input2( pm, "Key", PORT_LATENCY);
-    CHECK_THROWS_AS( pm->init(), PortError);
-}
-
-TEST_CASE("Ports: fanout underload")
-{
-    auto pm = PortMap::create_port_map();
-    ReadPort<int> input( pm, "Key", PORT_LATENCY);
-    WritePort<int> output( pm, "Key", PORT_BW, PORT_FANOUT * 2);
-    CHECK_THROWS_AS( pm->init(), PortError);
+    WritePort<int> output( pm, "Key", PORT_BW);
+    CHECK_THROWS_AS( WritePort<int>( pm, "Key", PORT_BW), PortError);
 }
 
 TEST_CASE("Ports: type mismatch")
 {
     auto pm = PortMap::create_port_map();
     ReadPort<int> input( pm, "Key", PORT_LATENCY);
-    WritePort<std::string> output( pm, "Key", PORT_BW, PORT_FANOUT);
+    WritePort<std::string> output( pm, "Key", PORT_BW);
     CHECK_THROWS_AS( pm->init(), PortError);
 }
 
@@ -62,7 +45,7 @@ get_pair_of_ports( const std::shared_ptr<PortMap>& pm, uint32 bw = PORT_BW, Late
 {
     PairOfPorts pop;
     pop.first = std::make_unique<ReadPort<int>>( pm, "Key", lat);
-    pop.second = std::make_unique<WritePort<int>>( pm, "Key", bw, PORT_FANOUT);
+    pop.second = std::make_unique<WritePort<int>>( pm, "Key", bw);
     pm->init();
     return pop;
 }

--- a/simulator/modules/branch/branch.cpp
+++ b/simulator/modules/branch/branch.cpp
@@ -6,24 +6,21 @@
 
 #include "branch.h"
 
-static constexpr const uint32 FLUSHED_STAGES_NUM = 4;
-
 template <typename FuncInstr>
 Branch<FuncInstr>::Branch( bool log) : Log( log)
 {
-    wp_flush_all = make_write_port<bool>("BRANCH_2_ALL_FLUSH", PORT_BW, FLUSHED_STAGES_NUM);
+    wp_flush_all = make_write_port<bool>("BRANCH_2_ALL_FLUSH", PORT_BW);
     rp_flush = make_read_port<bool>("BRANCH_2_ALL_FLUSH", PORT_LATENCY);
 
-    wp_flush_target = make_write_port<Target>("BRANCH_2_FETCH_TARGET", PORT_BW, PORT_FANOUT);
-    wp_bp_update = make_write_port<BPInterface>("BRANCH_2_FETCH", PORT_BW, PORT_FANOUT);
+    wp_flush_target = make_write_port<Target>("BRANCH_2_FETCH_TARGET", PORT_BW);
+    wp_bp_update = make_write_port<BPInterface>("BRANCH_2_FETCH", PORT_BW);
 
     rp_datapath = make_read_port<Instr>("EXECUTE_2_BRANCH", PORT_LATENCY);
-    wp_datapath = make_write_port<Instr>("BRANCH_2_WRITEBACK" , PORT_BW , PORT_FANOUT);    
+    wp_datapath = make_write_port<Instr>("BRANCH_2_WRITEBACK" , PORT_BW );    
 
-    wp_bypass = make_write_port<InstructionOutput>("BRANCH_2_EXECUTE_BYPASS", PORT_BW, SRC_REGISTERS_NUM);
+    wp_bypass = make_write_port<InstructionOutput>("BRANCH_2_EXECUTE_BYPASS", PORT_BW);
 
-    wp_bypassing_unit_flush_notify = make_write_port<bool>("BRANCH_2_BYPASSING_UNIT_FLUSH_NOTIFY", 
-                                                                PORT_BW, PORT_FANOUT);
+    wp_bypassing_unit_flush_notify = make_write_port<bool>("BRANCH_2_BYPASSING_UNIT_FLUSH_NOTIFY", PORT_BW);
 }
 
 template <typename FuncInstr>

--- a/simulator/modules/branch/branch.h
+++ b/simulator/modules/branch/branch.h
@@ -37,8 +37,6 @@ class Branch : public Log
         std::unique_ptr<WritePort<InstructionOutput>> wp_bypass = nullptr;
 
         std::unique_ptr<WritePort<bool>> wp_bypassing_unit_flush_notify = nullptr;
-
-        static constexpr const uint8 SRC_REGISTERS_NUM = 2;
     public:
         explicit Branch( bool log);
         void clock( Cycle cycle);

--- a/simulator/modules/core/perf_sim.cpp
+++ b/simulator/modules/core/perf_sim.cpp
@@ -21,7 +21,7 @@ PerfSim<ISA>::PerfSim( Endian endian, bool log) :
     branch( log),
     writeback( endian, log)
 {
-    wp_core_2_fetch_target = make_write_port<Target>("CORE_2_FETCH_TARGET", PORT_BW, PORT_FANOUT);
+    wp_core_2_fetch_target = make_write_port<Target>("CORE_2_FETCH_TARGET", PORT_BW);
     rp_halt = make_read_port<bool>("WRITEBACK_2_CORE_HALT", PORT_LATENCY);
 
     decode.set_RF( &rf);

--- a/simulator/modules/decode/decode.cpp
+++ b/simulator/modules/decode/decode.cpp
@@ -7,8 +7,6 @@
 
 #include "decode.h"
 
-static constexpr const uint32 FLUSHED_STAGES_NUM = 1;
-
 namespace config {
     extern Value<uint64> long_alu_latency;
 } // namespace config

--- a/simulator/modules/decode/decode.cpp
+++ b/simulator/modules/decode/decode.cpp
@@ -25,15 +25,15 @@ Decode<FuncInstr>::Decode( bool log) : Log( log)
     rp_bypassing_unit_flush_notify = make_read_port<bool>("BRANCH_2_BYPASSING_UNIT_FLUSH_NOTIFY", PORT_LATENCY);
     rp_flush_fetch = make_read_port<bool>("DECODE_2_FETCH_FLUSH", PORT_LATENCY);
 
-    wp_datapath = make_write_port<Instr>("DECODE_2_EXECUTE", PORT_BW, PORT_FANOUT);
-    wp_stall_datapath = make_write_port<Instr>("DECODE_2_DECODE", PORT_BW, PORT_FANOUT);
-    wp_stall = make_write_port<bool>("DECODE_2_FETCH_STALL", PORT_BW, PORT_FANOUT);
-    wps_command[0] = make_write_port<BypassCommand<Register>>("DECODE_2_EXECUTE_SRC1_COMMAND", PORT_BW, PORT_FANOUT);
-    wps_command[1] = make_write_port<BypassCommand<Register>>("DECODE_2_EXECUTE_SRC2_COMMAND", PORT_BW, PORT_FANOUT);
-    wp_bypassing_unit_notify = make_write_port<Instr>("DECODE_2_BYPASSING_UNIT_NOTIFY", PORT_BW, PORT_FANOUT);
-    wp_flush_fetch = make_write_port<bool>("DECODE_2_FETCH_FLUSH", PORT_BW, FLUSHED_STAGES_NUM);
-    wp_flush_target = make_write_port<Target>("DECODE_2_FETCH_TARGET", PORT_BW, PORT_FANOUT);
-    wp_bp_update = make_write_port<BPInterface>("DECODE_2_FETCH", PORT_BW, PORT_FANOUT);
+    wp_datapath = make_write_port<Instr>("DECODE_2_EXECUTE", PORT_BW);
+    wp_stall_datapath = make_write_port<Instr>("DECODE_2_DECODE", PORT_BW);
+    wp_stall = make_write_port<bool>("DECODE_2_FETCH_STALL", PORT_BW);
+    wps_command[0] = make_write_port<BypassCommand<Register>>("DECODE_2_EXECUTE_SRC1_COMMAND", PORT_BW);
+    wps_command[1] = make_write_port<BypassCommand<Register>>("DECODE_2_EXECUTE_SRC2_COMMAND", PORT_BW);
+    wp_bypassing_unit_notify = make_write_port<Instr>("DECODE_2_BYPASSING_UNIT_NOTIFY", PORT_BW);
+    wp_flush_fetch = make_write_port<bool>("DECODE_2_FETCH_FLUSH", PORT_BW);
+    wp_flush_target = make_write_port<Target>("DECODE_2_FETCH_TARGET", PORT_BW);
+    wp_bp_update = make_write_port<BPInterface>("DECODE_2_FETCH", PORT_BW);
 }
 
 template <typename FuncInstr>

--- a/simulator/modules/execute/execute.cpp
+++ b/simulator/modules/execute/execute.cpp
@@ -16,9 +16,9 @@ Execute<FuncInstr>::Execute( bool log)
     : Log( log)
     , last_execution_stage_latency( Latency( config::long_alu_latency - 1))
 {
-    wp_mem_datapath = make_write_port<Instr>("EXECUTE_2_MEMORY" , PORT_BW , PORT_FANOUT);
-    wp_branch_datapath = make_write_port<Instr>("EXECUTE_2_BRANCH" , PORT_BW , PORT_FANOUT);
-    wp_writeback_datapath = make_write_port<Instr>("EXECUTE_2_WRITEBACK", PORT_BW, PORT_FANOUT);
+    wp_mem_datapath = make_write_port<Instr>("EXECUTE_2_MEMORY" , PORT_BW );
+    wp_branch_datapath = make_write_port<Instr>("EXECUTE_2_BRANCH" , PORT_BW );
+    wp_writeback_datapath = make_write_port<Instr>("EXECUTE_2_WRITEBACK", PORT_BW);
     rp_datapath = make_read_port<Instr>("DECODE_2_EXECUTE", PORT_LATENCY);
 
     if (config::long_alu_latency < 2)
@@ -27,18 +27,16 @@ Execute<FuncInstr>::Execute( bool log)
     if (config::long_alu_latency > 64)
         throw Exception("Wrong argument! Latency of long arithmetic logic unit should be less than 64");
 
-    wp_long_latency_execution_unit = make_write_port<Instr>("EXECUTE_2_EXECUTE_LONG_LATENCY", PORT_BW, PORT_FANOUT);
-    rp_long_latency_execution_unit = make_read_port<Instr>("EXECUTE_2_EXECUTE_LONG_LATENCY",
-                                                           last_execution_stage_latency);
+    wp_long_latency_execution_unit = make_write_port<Instr>("EXECUTE_2_EXECUTE_LONG_LATENCY", PORT_BW);
+    rp_long_latency_execution_unit = make_read_port<Instr>("EXECUTE_2_EXECUTE_LONG_LATENCY", last_execution_stage_latency);
 
     rp_flush = make_read_port<bool>("BRANCH_2_ALL_FLUSH", PORT_LATENCY);
 
     rps_bypass[0].command_port = make_read_port<BypassCommand<Register>>("DECODE_2_EXECUTE_SRC1_COMMAND", PORT_LATENCY);
     rps_bypass[1].command_port = make_read_port<BypassCommand<Register>>("DECODE_2_EXECUTE_SRC2_COMMAND", PORT_LATENCY);
 
-    wp_bypass = make_write_port<InstructionOutput>("EXECUTE_2_EXECUTE_BYPASS", PORT_BW, SRC_REGISTERS_NUM);
-    wp_long_arithmetic_bypass = make_write_port<InstructionOutput>("EXECUTE_COMPLEX_ALU_2_EXECUTE_BYPASS",
-                                                               PORT_BW, SRC_REGISTERS_NUM);
+    wp_bypass = make_write_port<InstructionOutput>("EXECUTE_2_EXECUTE_BYPASS", PORT_BW);
+    wp_long_arithmetic_bypass = make_write_port<InstructionOutput>("EXECUTE_COMPLEX_ALU_2_EXECUTE_BYPASS", PORT_BW);
 
     rps_bypass[0].data_ports[0] = make_read_port<InstructionOutput>("EXECUTE_2_EXECUTE_BYPASS", PORT_LATENCY);
     rps_bypass[1].data_ports[0] = make_read_port<InstructionOutput>("EXECUTE_2_EXECUTE_BYPASS", PORT_LATENCY);

--- a/simulator/modules/execute/execute.h
+++ b/simulator/modules/execute/execute.h
@@ -18,7 +18,7 @@ class Execute : public Log
     using RegisterUInt = typename FuncInstr::RegisterUInt;
     using InstructionOutput = std::pair< RegisterUInt, RegisterUInt>;
 
-    private:   
+    private:
         static constexpr const uint8 SRC_REGISTERS_NUM = 2;
         const Latency last_execution_stage_latency;
 

--- a/simulator/modules/fetch/fetch.cpp
+++ b/simulator/modules/fetch/fetch.cpp
@@ -17,25 +17,25 @@ namespace config {
 template <typename FuncInstr>
 Fetch<FuncInstr>::Fetch(bool log) : Log( log)
 {
-    wp_datapath = make_write_port<Instr>("FETCH_2_DECODE", PORT_BW, PORT_FANOUT);
+    wp_datapath = make_write_port<Instr>("FETCH_2_DECODE", PORT_BW);
     rp_stall = make_read_port<bool>("DECODE_2_FETCH_STALL", PORT_LATENCY);
 
     rp_flush_target = make_read_port<Target>("BRANCH_2_FETCH_TARGET", PORT_LATENCY);
 
-    wp_target = make_write_port<Target>("TARGET", PORT_BW, PORT_FANOUT);
+    wp_target = make_write_port<Target>("TARGET", PORT_BW);
     rp_target = make_read_port<Target>("TARGET", PORT_LATENCY);
 
-    wp_hold_pc = make_write_port<Target>("HOLD_PC", PORT_BW, PORT_FANOUT);
+    wp_hold_pc = make_write_port<Target>("HOLD_PC", PORT_BW);
     rp_hold_pc = make_read_port<Target>("HOLD_PC", PORT_LATENCY);
 
     rp_external_target = make_read_port<Target>("CORE_2_FETCH_TARGET", PORT_LATENCY);
 
     rp_bp_update = make_read_port<BPInterface>("BRANCH_2_FETCH", PORT_LATENCY);
 
-    wp_long_latency_pc_holder = make_write_port<Target>("LONG_LATENCY_PC_HOLDER", PORT_BW, PORT_FANOUT);
+    wp_long_latency_pc_holder = make_write_port<Target>("LONG_LATENCY_PC_HOLDER", PORT_BW);
     rp_long_latency_pc_holder = make_read_port<Target>("LONG_LATENCY_PC_HOLDER", PORT_LONG_LATENCY);
 
-    wp_hit_or_miss = make_write_port<bool>("HIT_OR_MISS", PORT_BW, PORT_FANOUT);
+    wp_hit_or_miss = make_write_port<bool>("HIT_OR_MISS", PORT_BW);
     rp_hit_or_miss = make_read_port<bool>("HIT_OR_MISS", PORT_LATENCY);
 
     /* port needed for handling misprediction at decode stage */

--- a/simulator/modules/mem/mem.cpp
+++ b/simulator/modules/mem/mem.cpp
@@ -9,12 +9,12 @@
 template <typename FuncInstr>
 Mem<FuncInstr>::Mem( bool log) : Log( log)
 {
-    wp_datapath = make_write_port<Instr>("MEMORY_2_WRITEBACK", PORT_BW, PORT_FANOUT);
+    wp_datapath = make_write_port<Instr>("MEMORY_2_WRITEBACK", PORT_BW);
     rp_datapath = make_read_port<Instr>("EXECUTE_2_MEMORY", PORT_LATENCY);
 
     rp_flush = make_read_port<bool>("BRANCH_2_ALL_FLUSH", PORT_LATENCY);
 
-    wp_bypass = make_write_port<InstructionOutput>("MEMORY_2_EXECUTE_BYPASS", PORT_BW, SRC_REGISTERS_NUM);
+    wp_bypass = make_write_port<InstructionOutput>("MEMORY_2_EXECUTE_BYPASS", PORT_BW);
 }
 
 template <typename FuncInstr>

--- a/simulator/modules/mem/mem.h
+++ b/simulator/modules/mem/mem.h
@@ -29,8 +29,6 @@ class Mem : public Log
 
         std::unique_ptr<WritePort<InstructionOutput>> wp_bypass = nullptr;
 
-        static constexpr const uint8 SRC_REGISTERS_NUM = 2;
-
     public:
         explicit Mem( bool log);
         void clock( Cycle cycle);

--- a/simulator/modules/ports_instance.h
+++ b/simulator/modules/ports_instance.h
@@ -50,9 +50,9 @@ template<typename T> class BypassCommand;
 #undef PORT_TOKEN
 
 template<typename T>
-auto make_write_port( std::string key, uint32 bandwidth, uint32 fanout) 
+auto make_write_port( std::string key, uint32 bandwidth) 
 {
-    return std::make_unique<WritePort<T>>( PortMap::get_instance(), std::move(key), bandwidth, fanout);
+    return std::make_unique<WritePort<T>>( PortMap::get_instance(), std::move(key), bandwidth);
 }
 
 template<typename T>

--- a/simulator/modules/writeback/writeback.cpp
+++ b/simulator/modules/writeback/writeback.cpp
@@ -10,8 +10,8 @@ Writeback<ISA>::Writeback( Endian endian, bool log) : Log( log), endian( endian)
     rp_execute_datapath = make_read_port<Instr>("EXECUTE_2_WRITEBACK", PORT_LATENCY);
     rp_branch_datapath = make_read_port<Instr>("BRANCH_2_WRITEBACK", PORT_LATENCY);
 
-    wp_bypass = make_write_port<std::pair<RegisterUInt, RegisterUInt>>("WRITEBACK_2_EXECUTE_BYPASS", PORT_BW, SRC_REGISTERS_NUM);
-    wp_halt = make_write_port<bool>("WRITEBACK_2_CORE_HALT", PORT_BW, PORT_FANOUT);
+    wp_bypass = make_write_port<std::pair<RegisterUInt, RegisterUInt>>("WRITEBACK_2_EXECUTE_BYPASS", PORT_BW);
+    wp_halt = make_write_port<bool>("WRITEBACK_2_CORE_HALT", PORT_BW);
 }
 
 template<typename ISA>

--- a/simulator/modules/writeback/writeback.h
+++ b/simulator/modules/writeback/writeback.h
@@ -39,8 +39,6 @@ private:
     /* Simulator internals */
     RF<FuncInstr>* rf = nullptr;
 
-    static constexpr const uint8 SRC_REGISTERS_NUM = 2;
-
     auto read_instructions( Cycle cycle);
     void writeback_instruction( const Instr& instr, Cycle cycle);
     void writeback_bubble( Cycle cycle);


### PR DESCRIPTION
Defining fanout introduces backward dependencies between modules,
breaking the independent development