### PR TITLE
Make Module object owner of its Ports

### DIFF
--- a/simulator/infra/ports/module.cpp
+++ b/simulator/infra/ports/module.cpp
@@ -49,18 +49,18 @@ void Module::enable_logging_impl( const std::unordered_set<std::string>& names)
 
 pt::ptree Module::write_ports_dumping() const
 {
-    pt::ptree write_ports;
-    for ( const auto& k : topology_write_ports)
-        write_ports.put(k, "");
-    return write_ports;
+    pt::ptree result;
+    for ( const auto& p : write_ports)
+        result.put( p->get_key(), "");
+    return result;
 }
 
 pt::ptree Module::read_ports_dumping() const
 {
-    pt::ptree read_ports;
-    for ( const auto& k : topology_read_ports) 
-        read_ports.put(k, "");
-    return read_ports;
+    pt::ptree result;
+    for ( const auto& p : read_ports) 
+        result.put( p->get_key(), "");
+    return result;
 }
 
 void Module::module_dumping( pt::ptree* modules) const

--- a/simulator/infra/ports/module.h
+++ b/simulator/infra/ports/module.h
@@ -24,15 +24,19 @@ protected:
     template<typename T>
     auto make_write_port( std::string key, uint32 bandwidth) 
     {
-        topology_write_ports.emplace_back( key);
-        return std::make_unique<WritePort<T>>( get_portmap(), std::move( key), bandwidth);
+        auto port = std::make_unique<WritePort<T>>( get_portmap(), std::move(key), bandwidth);
+        auto ptr = port.get();
+        write_ports.emplace_back( std::move( port));
+        return ptr;
     }
 
     template<typename T>
     auto make_read_port( std::string key, Latency latency)
     {
-        topology_read_ports.emplace_back( key);
-        return std::make_unique<ReadPort<T>>( get_portmap(), std::move( key), latency);
+        auto port = std::make_unique<ReadPort<T>>( get_portmap(), std::move(key), latency);
+        auto ptr = port.get();
+        read_ports.emplace_back( std::move( port));
+        return ptr;
     }
 
     void enable_logging_impl( const std::unordered_set<std::string>& names);
@@ -55,8 +59,8 @@ private:
     Module* const parent;
     std::vector<Module*> children;
     const std::string name;
-    std::vector<std::string> topology_write_ports;
-    std::vector<std::string> topology_read_ports;
+    std::vector<std::unique_ptr<BasicWritePort>> write_ports;
+    std::vector<std::unique_ptr<BasicReadPort>> read_ports;
 };
 
 class Root : public Module

--- a/simulator/infra/ports/t/example_test.cpp
+++ b/simulator/infra/ports/t/example_test.cpp
@@ -85,10 +85,10 @@ public:
     }
 
 private:
-    std::unique_ptr<WritePort<int>> to_B;
-    std::unique_ptr<ReadPort<int>> from_B;
-    std::unique_ptr<ReadPort<int>> init;
-    std::unique_ptr<WritePort<bool>> stop;
+    WritePort<int>* to_B;
+    ReadPort<int>* from_B;
+    ReadPort<int>* init;
+    WritePort<bool>* stop;
 };
 
 class B : public Module
@@ -113,8 +113,8 @@ public:
     }
 
 private:
-    std::unique_ptr<WritePort<int>> to_A;
-    std::unique_ptr<ReadPort<int>> from_A;
+    WritePort<int>* to_A;
+    ReadPort<int>* from_A;
 };
 
 class TestRoot : public Root
@@ -149,8 +149,8 @@ private:
     A a;
     B b;
 
-    std::unique_ptr<WritePort<int>> init;
-    std::unique_ptr<ReadPort<bool>> stop;
+    WritePort<int>* init;
+    ReadPort<bool>* stop;
 };
 
 TEST_CASE( "test_ports: Test_Ports_A_B")

--- a/simulator/infra/ports/t/topology_test.cpp
+++ b/simulator/infra/ports/t/topology_test.cpp
@@ -24,10 +24,10 @@ struct SomeTopology : public Root
         explicit TestModule( Module* root, const std::string& name) : Module( root, name) { }
     };
     struct A : public TestModule {
-        std::unique_ptr<WritePort<int>> to_C;
-        std::unique_ptr<WritePort<int>> to_D;
-        std::unique_ptr<ReadPort<int>> from_C;
-        std::unique_ptr<ReadPort<int>> from_D;
+        WritePort<int>* to_C;
+        WritePort<int>* to_D;
+        ReadPort<int>* from_C;
+        ReadPort<int>* from_D;
         explicit A( Module* root) : TestModule( root, "A")
         {
             to_C = make_write_port<int>( "A_to_C", PORT_BW);
@@ -37,10 +37,10 @@ struct SomeTopology : public Root
         }
     };
     struct B : public TestModule {
-        std::unique_ptr<WritePort<int>> to_C;
-        std::unique_ptr<WritePort<int>> to_D;
-        std::unique_ptr<ReadPort<int>> from_C;
-        std::unique_ptr<ReadPort<int>> from_D;
+        WritePort<int>* to_C;
+        WritePort<int>* to_D;
+        ReadPort<int>* from_C;
+        ReadPort<int>* from_D;
         explicit B( Module* root) : TestModule( root, "B")
         {
             to_C = make_write_port<int>( "B_to_C", PORT_BW);
@@ -50,10 +50,10 @@ struct SomeTopology : public Root
         }
     };
     struct C : public TestModule {
-        std::unique_ptr<WritePort<int>> to_A;
-        std::unique_ptr<WritePort<int>> to_B;
-        std::unique_ptr<ReadPort<int>> from_A;
-        std::unique_ptr<ReadPort<int>> from_B;
+        WritePort<int>* to_A;
+        WritePort<int>* to_B;
+        ReadPort<int>* from_A;
+        ReadPort<int>* from_B;
         explicit C( Module* root) : TestModule( root, "C")
         {
             to_A = make_write_port<int>( "C_to_A", PORT_BW);
@@ -63,10 +63,10 @@ struct SomeTopology : public Root
         }
     };
     struct D : public TestModule {
-        std::unique_ptr<WritePort<int>> to_A;
-        std::unique_ptr<WritePort<int>> to_B;
-        std::unique_ptr<ReadPort<int>> from_A;
-        std::unique_ptr<ReadPort<int>> from_B;
+        WritePort<int>* to_A;
+        WritePort<int>* to_B;
+        ReadPort<int>* from_A;
+        ReadPort<int>* from_B;
         explicit D( Module* root) : TestModule( root, "D")
         {
             to_A = make_write_port<int>( "D_to_A", PORT_BW);

--- a/simulator/infra/ports/t/unit_test.cpp
+++ b/simulator/infra/ports/t/unit_test.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Ports: no write port")
     {
         TestRoot()
         {
-            auto input = make_read_port<int>( "Key", PORT_LATENCY);
+            make_read_port<int>( "Key", PORT_LATENCY);
             CHECK_THROWS_AS( init_portmap(), PortError);
         }
     } tr;
@@ -37,7 +37,7 @@ TEST_CASE("Ports: no read port")
     {
         TestRoot()
         {
-            auto output = make_write_port<int>( "Yek", PORT_BW);
+            make_write_port<int>( "Yek", PORT_BW);
             CHECK_THROWS_AS( init_portmap(), PortError);
         }
     } tr;
@@ -49,8 +49,8 @@ TEST_CASE("Ports: two write ports")
     {
         TestRoot()
         {
-            auto input = make_read_port<int>( "Key", PORT_LATENCY);
-            auto output = make_write_port<int>( "Key", PORT_BW);
+            make_read_port<int>( "Key", PORT_LATENCY);
+            make_write_port<int>( "Key", PORT_BW);
             CHECK_THROWS_AS( make_write_port<int>( "Key", PORT_BW), PortError);
         }
     } tr;
@@ -62,8 +62,8 @@ TEST_CASE("Ports: type mismatch")
     {
         TestRoot()
         {
-            auto input = make_read_port<int>( "Key", PORT_LATENCY);
-            auto output = make_write_port<std::string>( "Key", PORT_BW);
+            make_read_port<int>( "Key", PORT_LATENCY);
+            make_write_port<std::string>( "Key", PORT_BW);
             CHECK_THROWS_AS( init_portmap(), PortError);
         }
     } tr;
@@ -71,8 +71,8 @@ TEST_CASE("Ports: type mismatch")
 
 struct PairOfPorts : public BaseTestRoot
 {
-    std::unique_ptr<ReadPort<int>> rp;
-    std::unique_ptr<WritePort<int>> wp;
+    ReadPort<int>* rp;
+    WritePort<int>* wp;
 
     explicit PairOfPorts( uint32 bw = PORT_BW, Latency lat = PORT_LATENCY)
     {

--- a/simulator/modules/branch/branch.h
+++ b/simulator/modules/branch/branch.h
@@ -23,21 +23,21 @@ class Branch : public Module
         uint64 num_mispredictions = 0;
         uint64 num_jumps          = 0;
 
-        std::unique_ptr<ReadPort<Instr>> rp_datapath = nullptr;
-        std::unique_ptr<WritePort<Instr>> wp_datapath = nullptr;
+        ReadPort<Instr>* rp_datapath = nullptr;
+        WritePort<Instr>* wp_datapath = nullptr;
 
-        std::unique_ptr<WritePort<bool>> wp_flush_all = nullptr;
-        std::unique_ptr<ReadPort<bool>> rp_flush = nullptr;
-        std::unique_ptr<ReadPort<bool>> rp_trap = nullptr;
+        WritePort<bool>* wp_flush_all = nullptr;
+        ReadPort<bool>* rp_flush = nullptr;
+        ReadPort<bool>* rp_trap = nullptr;
 
-        std::unique_ptr<WritePort<Target>> wp_flush_target = nullptr;
-        std::unique_ptr<WritePort<BPInterface>> wp_bp_update = nullptr;
+        WritePort<Target>* wp_flush_target = nullptr;
+        WritePort<BPInterface>* wp_bp_update = nullptr;
 
-        std::unique_ptr<ReadPort<Instr>> rp_recive_datapath_from_mem = nullptr;
+        ReadPort<Instr>* rp_recive_datapath_from_mem = nullptr;
 
-        std::unique_ptr<WritePort<InstructionOutput>> wp_bypass = nullptr;
+        WritePort<InstructionOutput>* wp_bypass = nullptr;
 
-        std::unique_ptr<WritePort<bool>> wp_bypassing_unit_flush_notify = nullptr;
+        WritePort<bool>* wp_bypassing_unit_flush_notify = nullptr;
 
     public:
         explicit Branch( Module* parent);

--- a/simulator/modules/core/perf_sim.h
+++ b/simulator/modules/core/perf_sim.h
@@ -77,7 +77,7 @@ private:
     Writeback<ISA> writeback;
 
     /* ports */
-    std::unique_ptr<ReadPort<Trap>> rp_halt = nullptr;
+    ReadPort<Trap>* rp_halt = nullptr;
 
     void clock_tree( Cycle cycle);
     void dump_statistics() const;

--- a/simulator/modules/decode/decode.h
+++ b/simulator/modules/decode/decode.h
@@ -41,23 +41,23 @@ private:
     std::unique_ptr<BypassingUnit> bypassing_unit = nullptr;
 
     /* Inputs */
-    std::unique_ptr<ReadPort<Instr>> rp_datapath = nullptr;
-    std::unique_ptr<ReadPort<Instr>> rp_stall_datapath = nullptr;
-    std::unique_ptr<ReadPort<bool>> rp_flush = nullptr;
-    std::unique_ptr<ReadPort<Instr>> rp_bypassing_unit_notify = nullptr;
-    std::unique_ptr<ReadPort<bool>> rp_bypassing_unit_flush_notify = nullptr;
-    std::unique_ptr<ReadPort<bool>> rp_flush_fetch = nullptr;
-    std::unique_ptr<ReadPort<bool>> rp_trap = nullptr;
+    ReadPort<Instr>* rp_datapath = nullptr;
+    ReadPort<Instr>* rp_stall_datapath = nullptr;
+    ReadPort<bool>* rp_flush = nullptr;
+    ReadPort<Instr>* rp_bypassing_unit_notify = nullptr;
+    ReadPort<bool>* rp_bypassing_unit_flush_notify = nullptr;
+    ReadPort<bool>* rp_flush_fetch = nullptr;
+    ReadPort<bool>* rp_trap = nullptr;
 
     /* Outputs */
-    std::unique_ptr<WritePort<Instr>> wp_datapath = nullptr;
-    std::unique_ptr<WritePort<Instr>> wp_stall_datapath = nullptr;
-    std::unique_ptr<WritePort<bool>> wp_stall = nullptr;
-    std::unique_ptr<WritePort<Instr>> wp_bypassing_unit_notify = nullptr;
-    std::unique_ptr<WritePort<BPInterface>> wp_bp_update = nullptr;
-    std::array<std::unique_ptr<WritePort<BypassCommand<Register>>>, SRC_REGISTERS_NUM> wps_command;
-    std::unique_ptr<WritePort<bool>> wp_flush_fetch = nullptr;
-    std::unique_ptr<WritePort<Target>> wp_flush_target = nullptr;
+    WritePort<Instr>* wp_datapath = nullptr;
+    WritePort<Instr>* wp_stall_datapath = nullptr;
+    WritePort<bool>* wp_stall = nullptr;
+    WritePort<Instr>* wp_bypassing_unit_notify = nullptr;
+    WritePort<BPInterface>* wp_bp_update = nullptr;
+    std::array<WritePort<BypassCommand<Register>>*, SRC_REGISTERS_NUM> wps_command;
+    WritePort<bool>* wp_flush_fetch = nullptr;
+    WritePort<Target>* wp_flush_target = nullptr;
 };
 
 

--- a/simulator/modules/execute/execute.h
+++ b/simulator/modules/execute/execute.h
@@ -23,24 +23,24 @@ class Execute : public Module
         const Latency last_execution_stage_latency;
 
         /* Inputs */
-        std::unique_ptr<ReadPort<Instr>> rp_datapath = nullptr;
-        std::unique_ptr<ReadPort<Instr>> rp_long_latency_execution_unit = nullptr;
-        std::unique_ptr<ReadPort<bool>> rp_flush = nullptr;
-        std::unique_ptr<ReadPort<bool>> rp_trap = nullptr;
+        ReadPort<Instr>* rp_datapath = nullptr;
+        ReadPort<Instr>* rp_long_latency_execution_unit = nullptr;
+        ReadPort<bool>* rp_flush = nullptr;
+        ReadPort<bool>* rp_trap = nullptr;
 
         struct BypassPorts {
-            std::unique_ptr<ReadPort<BypassCommand<Register>>> command_port;
-            std::array<std::unique_ptr<ReadPort<InstructionOutput>>, RegisterStage::BYPASSING_STAGES_NUMBER> data_ports;
+            ReadPort<BypassCommand<Register>>* command_port;
+            std::array<ReadPort<InstructionOutput>*, RegisterStage::BYPASSING_STAGES_NUMBER> data_ports;
         };
         std::array<BypassPorts, SRC_REGISTERS_NUM> rps_bypass;
 
         /* Outputs */
-        std::unique_ptr<WritePort<Instr>> wp_mem_datapath = nullptr;
-        std::unique_ptr<WritePort<Instr>> wp_branch_datapath = nullptr;
-        std::unique_ptr<WritePort<Instr>> wp_writeback_datapath = nullptr;
-        std::unique_ptr<WritePort<Instr>> wp_long_latency_execution_unit = nullptr;
-        std::unique_ptr<WritePort<InstructionOutput>> wp_bypass = nullptr;
-        std::unique_ptr<WritePort<InstructionOutput>> wp_long_arithmetic_bypass = nullptr;
+        WritePort<Instr>* wp_mem_datapath = nullptr;
+        WritePort<Instr>* wp_branch_datapath = nullptr;
+        WritePort<Instr>* wp_writeback_datapath = nullptr;
+        WritePort<Instr>* wp_long_latency_execution_unit = nullptr;
+        WritePort<InstructionOutput>* wp_bypass = nullptr;
+        WritePort<InstructionOutput>* wp_long_arithmetic_bypass = nullptr;
 
         Latency flush_expiration_latency = 0_lt;
 

--- a/simulator/modules/fetch/fetch.h
+++ b/simulator/modules/fetch/fetch.h
@@ -32,29 +32,29 @@ private:
     std::unique_ptr<CacheTagArray> tags = nullptr;
     
     /* Input signals */
-    std::unique_ptr<ReadPort<bool>> rp_stall = nullptr;
-    std::unique_ptr<ReadPort<bool>> rp_hit_or_miss = nullptr;
+    ReadPort<bool>* rp_stall = nullptr;
+    ReadPort<bool>* rp_hit_or_miss = nullptr;
 
     /* Input signals - BP */
-    std::unique_ptr<ReadPort<BPInterface>> rp_bp_update = nullptr;
-    std::unique_ptr<ReadPort<BPInterface>> rp_bp_update_from_decode = nullptr;
+    ReadPort<BPInterface>* rp_bp_update = nullptr;
+    ReadPort<BPInterface>* rp_bp_update_from_decode = nullptr;
     
     /* Input signals - PC values */
-    std::unique_ptr<ReadPort<Target>> rp_flush_target = nullptr;
-    std::unique_ptr<ReadPort<Target>> rp_external_target = nullptr;
-    std::unique_ptr<ReadPort<Target>> rp_hold_pc = nullptr;
-    std::unique_ptr<ReadPort<Target>> rp_target = nullptr;
-    std::unique_ptr<ReadPort<Target>> rp_long_latency_pc_holder = nullptr;
+    ReadPort<Target>* rp_flush_target = nullptr;
+    ReadPort<Target>* rp_external_target = nullptr;
+    ReadPort<Target>* rp_hold_pc = nullptr;
+    ReadPort<Target>* rp_target = nullptr;
+    ReadPort<Target>* rp_long_latency_pc_holder = nullptr;
 
     /* Outputs */
-    std::unique_ptr<WritePort<Instr>> wp_datapath = nullptr;
-    std::unique_ptr<WritePort<Target>> wp_hold_pc = nullptr;
-    std::unique_ptr<WritePort<Target>> wp_target = nullptr;
-    std::unique_ptr<WritePort<Target>> wp_long_latency_pc_holder = nullptr;
-    std::unique_ptr<WritePort<bool>> wp_hit_or_miss = nullptr;
+    WritePort<Instr>* wp_datapath = nullptr;
+    WritePort<Target>* wp_hold_pc = nullptr;
+    WritePort<Target>* wp_target = nullptr;
+    WritePort<Target>* wp_long_latency_pc_holder = nullptr;
+    WritePort<bool>* wp_hit_or_miss = nullptr;
 
     /* port needed for habdling misprediction at decode stage */
-    std::unique_ptr<ReadPort<Target>> rp_flush_target_from_decode = nullptr;
+    ReadPort<Target>* rp_flush_target_from_decode = nullptr;
 
     Target get_target( Cycle cycle);
     Target get_cached_target( Cycle cycle);

--- a/simulator/modules/mem/mem.h
+++ b/simulator/modules/mem/mem.h
@@ -22,13 +22,13 @@ class Mem : public Module
     private:
         std::shared_ptr<FuncMemory> memory;
 
-        std::unique_ptr<WritePort<Instr>> wp_datapath = nullptr;
-        std::unique_ptr<ReadPort<Instr>> rp_datapath = nullptr;
+        WritePort<Instr>* wp_datapath = nullptr;
+        ReadPort<Instr>* rp_datapath = nullptr;
 
-        std::unique_ptr<ReadPort<bool>> rp_flush = nullptr;
-        std::unique_ptr<ReadPort<bool>> rp_trap = nullptr;
+        ReadPort<bool>* rp_flush = nullptr;
+        ReadPort<bool>* rp_trap = nullptr;
 
-        std::unique_ptr<WritePort<InstructionOutput>> wp_bypass = nullptr;
+        WritePort<InstructionOutput>* wp_bypass = nullptr;
 
     public:
         explicit Mem( Module* parent);

--- a/simulator/modules/writeback/writeback.cpp
+++ b/simulator/modules/writeback/writeback.cpp
@@ -28,7 +28,7 @@ void Writeback<ISA>::set_target( const Target& value, Cycle cycle)
 template <typename ISA>
 auto Writeback<ISA>::read_instructions( Cycle cycle)
 {
-    auto ports = { rp_branch_datapath.get(), rp_mem_datapath.get(), rp_execute_datapath.get() };
+    auto ports = { rp_branch_datapath, rp_mem_datapath, rp_execute_datapath };
     std::vector<Instr> result;
 
     for ( auto& port : ports)

--- a/simulator/modules/writeback/writeback.h
+++ b/simulator/modules/writeback/writeback.h
@@ -48,16 +48,16 @@ private:
     void writeback_bubble( Cycle cycle);
 
     /* Input */
-    std::unique_ptr<ReadPort<Instr>> rp_mem_datapath = nullptr;
-    std::unique_ptr<ReadPort<Instr>> rp_execute_datapath = nullptr;
-    std::unique_ptr<ReadPort<Instr>> rp_branch_datapath = nullptr;    
-    std::unique_ptr<ReadPort<bool>> rp_trap = nullptr;
+    ReadPort<Instr>* rp_mem_datapath = nullptr;
+    ReadPort<Instr>* rp_execute_datapath = nullptr;
+    ReadPort<Instr>* rp_branch_datapath = nullptr;    
+    ReadPort<bool>* rp_trap = nullptr;
 
     /* Output */
-    std::unique_ptr<WritePort<std::pair<RegisterUInt, RegisterUInt>>> wp_bypass = nullptr;
-    std::unique_ptr<WritePort<Trap>> wp_halt = nullptr;
-    std::unique_ptr<WritePort<bool>> wp_trap = nullptr;
-    std::unique_ptr<WritePort<Target>> wp_target = nullptr;
+    WritePort<std::pair<RegisterUInt, RegisterUInt>>* wp_bypass = nullptr;
+    WritePort<Trap>* wp_halt = nullptr;
+    WritePort<bool>* wp_trap = nullptr;
+    WritePort<Target>* wp_target = nullptr;
 
 public:
     Writeback( Module* parent, Endian endian);


### PR DESCRIPTION
Now there is no need to declare ports with ugly
std::unique_ptr<ReadPort<LongTokenName>>, straightforward
ReadPort<LongTokenName>* should be used instead