### PR TITLE
Move exception handling to new class

### DIFF
--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 set(CPPS
     infra/print128.cpp
+    infra/config/main_wrapper.cpp
     infra/config/config.cpp
     infra/ports/module.cpp
     infra/ports/ports.cpp

--- a/simulator/export/standalone/main.cpp
+++ b/simulator/export/standalone/main.cpp
@@ -21,26 +21,28 @@ class Main : public MainWrapper
 {
     using MainWrapper::MainWrapper;
 private:
-    int impl( int argc, const char* argv[]) const final {
-        config::handleArgs( argc, argv, 1);
-        auto memory = FuncMemory::create_default_hierarchied_memory();
-
-        auto sim = Simulator::create_configured_simulator();
-        sim->set_memory( memory);
-        sim->write_csr_register( "mscratch", 0x400'0000);
-
-        auto kernel = Kernel::create_configured_kernel();
-        kernel->connect_memory( memory);
-        kernel->set_simulator( sim);
-        kernel->load_file( config::binary_filename);
-        sim->set_kernel( kernel);
-
-        sim->init_checker();
-        sim->set_pc( kernel->get_start_pc());
-        sim->run( config::num_steps);
-        return sim->get_exit_code();
-    }
+    int impl( int argc, const char* argv[]) const final; 
 };
+
+int Main::impl( int argc, const char* argv[]) const {
+    config::handleArgs( argc, argv, 1);
+    auto memory = FuncMemory::create_default_hierarchied_memory();
+
+    auto sim = Simulator::create_configured_simulator();
+    sim->set_memory( memory);
+    sim->write_csr_register( "mscratch", 0x400'0000);
+
+    auto kernel = Kernel::create_configured_kernel();
+    kernel->connect_memory( memory);
+    kernel->set_simulator( sim);
+    kernel->load_file( config::binary_filename);
+    sim->set_kernel( kernel);
+
+    sim->init_checker();
+    sim->set_pc( kernel->get_start_pc());
+    sim->run( config::num_steps);
+    return sim->get_exit_code();
+}
 
 int main( int argc, const char* argv[]) {
     return Main( "Functional and performance simulators for MIPS-based CPU.").run( argc, argv);

--- a/simulator/infra/config/main_wrapper.cpp
+++ b/simulator/infra/config/main_wrapper.cpp
@@ -1,0 +1,30 @@
+/**
+ * main_wrapper.cpp - wrapper for entry points of MIPT-V binaries
+ * @author Pavel Kryukov
+ * Copyright 2019 MIPT-V
+ */
+
+#include "main_wrapper.h"
+
+#include <infra/config/config.h>
+#include <infra/exception.h>
+
+int MainWrapper::run( int argc, const char* argv[]) const try {
+    return impl( argc, argv);
+}
+catch ( const config::HelpOption& e) {
+    std::cout << desc << std::endl << std::endl << e.what() << std::endl;
+    return 0;
+}
+catch ( const Exception& e) {
+    std::cerr << e.what() << std::endl;
+    return 2;
+}
+catch ( const std::exception& e) {
+    std::cerr << "System exception:\t\n" << e.what() << std::endl;
+    return 2;
+}
+catch (...) {
+    std::cerr << "Unknown exception\n";
+    return 3;
+}

--- a/simulator/infra/config/main_wrapper.h
+++ b/simulator/infra/config/main_wrapper.h
@@ -1,0 +1,24 @@
+/**
+ * main_wrapper.h - wrapper for entry points of MIPT-V binaries
+ * @author Pavel Kryukov
+ * Copyright 2019 MIPT-V
+ */
+
+#ifndef MAIN_WRAPPER_H
+#define MAIN_WRAPPER_H
+
+#include <string_view>
+#include <string>
+
+class MainWrapper
+{
+public:
+    explicit MainWrapper( std::string_view desc) : desc( desc) { }
+    int run( int argc, const char* argv[]) const ;
+
+private:
+    virtual int impl( int argc, const char* argv[]) const = 0;
+    std::string desc;
+};
+
+#endif

--- a/simulator/infra/config/t/unit_test.cpp
+++ b/simulator/infra/config/t/unit_test.cpp
@@ -4,6 +4,8 @@
  */
 
 #include "../config.h"
+#include "../main_wrapper.h"
+
 #include "infra/argv.h"
 #include "infra/macro.h"
 
@@ -265,3 +267,47 @@ TEST_CASE( "config_provide_options: Provide_Config_Parser_With_Binary_Option_Twi
 }
 #endif
 
+TEST_CASE("MainWrapper: throw help")
+{
+    struct Main : public MainWrapper
+    {
+        Main() : MainWrapper( "Example Unit Test") { }
+        int impl( int, const char* []) const final { throw config::HelpOption( "Help!"); }
+    };
+
+    CHECK( Main().run( 0, nullptr) == 0);
+}
+
+TEST_CASE("MainWrapper: throw exception")
+{
+    struct Main : public MainWrapper
+    {
+        Main() : MainWrapper( "Example Unit Test") { }
+        int impl( int, const char* []) const final { throw Exception( "Exception"); }
+    };
+
+    CHECK( Main().run( 0, nullptr) == 2);
+}
+
+TEST_CASE("MainWrapper: throw std exception")
+{
+    struct Main : public MainWrapper
+    {
+        Main() : MainWrapper( "Example Unit Test") { }
+        int impl( int, const char* []) const final { throw std::exception(); }
+    };
+
+    CHECK( Main().run( 0, nullptr) == 2);
+}
+
+
+TEST_CASE("MainWrapper: throw integer")
+{
+    struct Main : public MainWrapper
+    {
+        Main() : MainWrapper( "Example Unit Test") { }
+        int impl( int, const char* []) const final { throw 222; }
+    };
+
+    CHECK( Main().run( 0, nullptr) == 3);
+}


### PR DESCRIPTION
This is required to avoid code duplication once we spawn new entry point for standalone cache simulator.