### PR TITLE
Handle invalid options with a new exception

### DIFF
--- a/simulator/infra/config/config.cpp
+++ b/simulator/infra/config/config.cpp
@@ -12,12 +12,20 @@ namespace config {
 static AliasedSwitch help_option = { "h", "help", "print help"};
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays, hicpp-avoid-c-arrays)
-void handleArgs( int argc, const char* const argv[], int start_index)
+void handleArgs( int argc, const char* const argv[], int start_index) try
 {
     BaseValue::options().parse( argc, argv, start_index);
 
     if ( help_option)
-        throw HelpOption( BaseValue::options().help());
+        throw HelpOption();
+}
+catch ( const popl::invalid_option& e) {
+    throw InvalidOption( e.what());
+}
+
+std::string help()
+{
+    return BaseValue::options().help();
 }
 
 popl::OptionParser& BaseValue::options()

--- a/simulator/infra/config/config.h
+++ b/simulator/infra/config/config.h
@@ -23,6 +23,7 @@ class BaseValue
 {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays, hicpp-avoid-c-arrays)
     friend void handleArgs( int argc, const char* const argv[], int start_index);
+    friend std::string help();
 protected:
     static popl::OptionParser& options();
     static void register_switch( const std::string& alias, const std::string& name, const std::string& desc, bool* value);
@@ -88,11 +89,17 @@ struct Switch : AliasedSwitch
 
 struct HelpOption : Exception
 {
-    explicit HelpOption( const std::string& msg) : Exception( "Help", msg) {}
+    HelpOption() : Exception( "Help") {}
+};
+
+struct InvalidOption : Exception
+{
+    explicit InvalidOption( const std::string& msg) : Exception( "Invalid option", msg) {}
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays, hicpp-avoid-c-arrays)
 void handleArgs( int argc, const char* const argv[], int start_index);
+std::string help();
 
 } // namespace config
 

--- a/simulator/infra/config/main_wrapper.cpp
+++ b/simulator/infra/config/main_wrapper.cpp
@@ -9,22 +9,32 @@
 #include <infra/config/config.h>
 #include <infra/exception.h>
 
+static const constexpr int EXCEPTION_EXIT_CODE = 2;
+static const constexpr int NO_EXCEPTION_EXIT_CODE = 3;
+static const constexpr int INVALID_OPTION_EXIT_CODE = 4;
+
 int MainWrapper::run( int argc, const char* argv[]) const try {
     return impl( argc, argv);
 }
-catch ( const config::HelpOption& e) {
-    std::cout << desc << std::endl << std::endl << e.what() << std::endl;
+catch ( const config::HelpOption&) {
+    std::cout << desc << std::endl << std::endl << config::help() << std::endl;
     return 0;
+}
+catch ( const config::InvalidOption& e) {
+    std::cerr << e.what() << std::endl
+        << desc << std::endl << std::endl
+        << config::help() << std::endl;
+    return INVALID_OPTION_EXIT_CODE;
 }
 catch ( const Exception& e) {
     std::cerr << e.what() << std::endl;
-    return 2;
+    return EXCEPTION_EXIT_CODE;
 }
 catch ( const std::exception& e) {
     std::cerr << "System exception:\t\n" << e.what() << std::endl;
-    return 2;
+    return EXCEPTION_EXIT_CODE;
 }
 catch (...) {
     std::cerr << "Unknown exception\n";
-    return 3;
+    return NO_EXCEPTION_EXIT_CODE;
 }

--- a/simulator/infra/config/t/unit_test.cpp
+++ b/simulator/infra/config/t/unit_test.cpp
@@ -106,7 +106,7 @@ TEST_CASE( "config_parse: Pass_No_Args")
         "mipt-mips", nullptr
     };
 
-    CHECK_THROWS_AS( handleArgs( argv), std::exception);
+    CHECK_THROWS_AS( handleArgs( argv), config::InvalidOption);
 }
 
 //
@@ -121,7 +121,7 @@ TEST_CASE( "config_parse: Pass_Args_Without_Binary_Option")
         nullptr
     };
     
-    CHECK_THROWS_AS( handleArgs( argv), std::exception);
+    CHECK_THROWS_AS( handleArgs( argv), config::InvalidOption);
 }
 
 //
@@ -136,7 +136,7 @@ TEST_CASE( "config_parse:  Pass_Args_Without_Numsteps_Option")
         nullptr
     };
 
-    CHECK_THROWS_AS( handleArgs( argv), std::exception);
+    CHECK_THROWS_AS( handleArgs( argv), config::InvalidOption);
 }
 
 //
@@ -153,7 +153,7 @@ TEST_CASE( "config_parse: Pass_Args_With_Unrecognised_Option")
         nullptr
     };
 
-    CHECK_THROWS_AS( handleArgs( argv), std::exception);
+    CHECK_THROWS_AS( handleArgs( argv), config::InvalidOption);
 }
 
 #if 0
@@ -171,7 +171,7 @@ TEST_CASE( "config_parse:  Pass_Binary_Option_Multiple_Times")
         nullptr
     };
 
-    CHECK_THROWS_AS( handleArgs( argv), std::exception);
+    CHECK_THROWS_AS( handleArgs( argv), config::InvalidOption);
 }
 #endif
 
@@ -188,7 +188,7 @@ TEST_CASE( "config_parse:  Pass_Binary_Option_Without_Arg")
         nullptr
     };
 
-    CHECK_THROWS_AS( handleArgs( argv), std::exception);
+    CHECK_THROWS_AS( handleArgs( argv), config::InvalidOption);
 }
 
 //
@@ -204,7 +204,7 @@ TEST_CASE( "config_parse:  Pass_Numsteps_Option_Without_Arg")
         nullptr
     };
 
-    CHECK_THROWS_AS( handleArgs( argv), std::exception);
+    CHECK_THROWS_AS( handleArgs( argv), config::InvalidOption);
 }
 
 TEST_CASE( "config_parse: Pass help option alias")
@@ -233,6 +233,18 @@ TEST_CASE( "config_parse: Pass help option")
     };
 
     CHECK_THROWS_AS( handleArgs( argv), config::HelpOption);
+}
+
+TEST_CASE( "config_parse: Pass help option and invalid option")
+{
+    std::vector<const char*> argv
+    {
+        "mipt-mips",
+        "--help",
+        nullptr
+    };
+
+    CHECK_THROWS_AS( handleArgs( argv), config::InvalidOption);
 }
 
 #if 0
@@ -272,10 +284,21 @@ TEST_CASE("MainWrapper: throw help")
     struct Main : public MainWrapper
     {
         Main() : MainWrapper( "Example Unit Test") { }
-        int impl( int, const char* []) const final { throw config::HelpOption( "Help!"); }
+        int impl( int, const char* []) const final { throw config::HelpOption(); }
     };
 
     CHECK( Main().run( 0, nullptr) == 0);
+}
+
+TEST_CASE("MainWrapper: invalid option")
+{
+    struct Main : public MainWrapper
+    {
+        Main() : MainWrapper( "Example Unit Test") { }
+        int impl( int, const char* []) const final { throw config::InvalidOption( "Help!"); }
+    };
+
+    CHECK( Main().run( 0, nullptr) == 4);
 }
 
 TEST_CASE("MainWrapper: throw exception")


### PR DESCRIPTION
Now help may be dumped even if no valid option is provided