### PR TITLE
Optimize ones-right-shift with MVC 19.23

### DIFF
--- a/simulator/infra/macro.h
+++ b/simulator/infra/macro.h
@@ -176,7 +176,7 @@ static constexpr T ones_ls( const T& value, size_t shamt)
 template<typename T>
 static constexpr T ones_rs( const T& value, size_t shamt)
 {
-#ifdef _MSC_VER
+#if definded(_MSC_FULL_VER) && (_MSC_FULL_VER < 192328105)
     // Workaround for Visual Studio bug
     // https://developercommunity.visualstudio.com/content/problem/833637/wrong-compilation-for-ones-right-shift.html
     const volatile auto x = ~value;

--- a/simulator/infra/macro.h
+++ b/simulator/infra/macro.h
@@ -176,7 +176,7 @@ static constexpr T ones_ls( const T& value, size_t shamt)
 template<typename T>
 static constexpr T ones_rs( const T& value, size_t shamt)
 {
-#if definded(_MSC_FULL_VER) && (_MSC_FULL_VER < 192328105)
+#if defined(_MSC_FULL_VER) && (_MSC_FULL_VER < 192328105)
     // Workaround for Visual Studio bug
     // https://developercommunity.visualstudio.com/content/problem/833637/wrong-compilation-for-ones-right-shift.html
     // TODO (pkryukov): remove once we switch to C++20

--- a/simulator/infra/macro.h
+++ b/simulator/infra/macro.h
@@ -179,6 +179,7 @@ static constexpr T ones_rs( const T& value, size_t shamt)
 #if definded(_MSC_FULL_VER) && (_MSC_FULL_VER < 192328105)
     // Workaround for Visual Studio bug
     // https://developercommunity.visualstudio.com/content/problem/833637/wrong-compilation-for-ones-right-shift.html
+    // TODO (pkryukov): remove once we switch to C++20
     const volatile auto x = ~value;
 #else
     const auto x = ~value;


### PR DESCRIPTION
According to bugtracker, issue has been fixed in the newest VC++ release: https://developercommunity.visualstudio.com/content/problem/833637/wrong-compilation-for-ones-right-shift.html