### PR TITLE
RISC-V: trim SLLI/SRLI/SRAI immediate

### DIFF
--- a/simulator/risc_v/riscv_decoder.h
+++ b/simulator/risc_v/riscv_decoder.h
@@ -200,6 +200,9 @@ struct RISCVInstrDecoder
     {
         switch (subset) {
         case 'I': return I_imm;
+        case '5': return I_imm & bitmask<uint32>( 5);
+        case '6': return I_imm & bitmask<uint32>( 6);
+        case '7': return I_imm & bitmask<uint32>( 7);
         case 'B': return get_B_immediate();
         case 'S': return S_imm4_0 | (S_imm11_5 << 5U);
         case 'U': return U_imm;
@@ -236,11 +239,14 @@ struct RISCVInstrDecoder
     static R get_immediate( char subset, uint32 value) noexcept
     {
         switch (subset) {
-        case I:
-        case B:
-        case S:          return sign_extension<12, R>( value);
-        case U:
-        case J:          return sign_extension<20, R>( value);
+        case '5':
+        case '6':
+        case '7':        return value & bitmask<R>( log_bitwidth<R>);
+        case 'I':
+        case 'B':
+        case 'S':        return sign_extension<12, R>( value);
+        case 'U':
+        case 'J':        return sign_extension<20, R>( value);
         case C_I:        return sign_extension<6, R>( value);
         case C_J:        return sign_extension<12, R>( value);
         case C_B:        return sign_extension<9, R>( value);

--- a/simulator/risc_v/riscv_instr.cpp
+++ b/simulator/risc_v/riscv_instr.cpp
@@ -203,17 +203,17 @@ static const std::vector<RISCVTableEntry<I>> cmd_desc =
     {'I', instr_sd,     execute_store<I>,  OUT_STORE,  'S', Imm::ADDR,  Src1::RS1,  Src2::RS2,  Dst::ZERO, 8,      64 | 128},
     // Immediate arithmetics
     {'I', instr_addi,   execute_addi<I>,   OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
-    {'I', instr_slli,   execute_slli<I>,   OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
-    {'I', instr_srli,   execute_srli<I>,   OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
-    {'I', instr_srai,   execute_srai<I>,   OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
+    {'I', instr_slli,   execute_slli<I>,   OUT_ARITHM, '7', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
+    {'I', instr_srli,   execute_srli<I>,   OUT_ARITHM, '7', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
+    {'I', instr_srai,   execute_srai<I>,   OUT_ARITHM, '7', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
     {'I', instr_addiw,  execute_addiw<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,      64 | 128},
-    {'I', instr_slliw,  execute_slliw<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,      64 | 128},
-    {'I', instr_srliw,  execute_srliw<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,      64 | 128},
-    {'I', instr_sraiw,  execute_sraiw<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,      64 | 128},
+    {'I', instr_slliw,  execute_slliw<I>,  OUT_ARITHM, '5', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,      64 | 128},
+    {'I', instr_srliw,  execute_srliw<I>,  OUT_ARITHM, '5', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,      64 | 128},
+    {'I', instr_sraiw,  execute_sraiw<I>,  OUT_ARITHM, '5', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,      64 | 128},
     {'I', instr_addid,  execute_addid<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,           128},
-    {'I', instr_sllid,  execute_sllid<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,           128},
-    {'I', instr_srlid,  execute_srlid<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,           128},
-    {'I', instr_sraid,  execute_sraid<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,           128},
+    {'I', instr_sllid,  execute_sllid<I>,  OUT_ARITHM, '6', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,           128},
+    {'I', instr_srlid,  execute_srlid<I>,  OUT_ARITHM, '6', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,           128},
+    {'I', instr_sraid,  execute_sraid<I>,  OUT_ARITHM, '6', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0,           128},
     // Immediate logic and comparison
     {'I', instr_slti,   execute_slti<I>,   OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
     {'I', instr_sltiu,  execute_sltiu<I>,  OUT_ARITHM, 'I', Imm::ARITH, Src1::RS1,  Src2::ZERO, Dst::RD,   0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977

--- a/simulator/risc_v/t/unit_test.cpp
+++ b/simulator/risc_v/t/unit_test.cpp
@@ -22,7 +22,6 @@ TEST_CASE("RISCV disassembly")
     CHECK( RISCVInstr<uint32>(0x30200073).get_disasm() == "mret");
     CHECK( RISCVInstr<uint32>(0x30202373).get_disasm() == "csrrs $medeleg, $t1, $zero");
     CHECK( RISCVInstr<uint32>(0x30205073).get_disasm() == "csrrwi $medeleg, $zero, 0x0");
-    CHECK( RISCVInstr<uint128>(0x4070df5b).get_disasm() == "sraid $t5, $ra, 1031");
     CHECK( RISCVInstr<uint32>    (0x4082).get_disasm() == "c_lwsp $ra, 0x0($sp)");
     CHECK( RISCVInstr<uint32>    (0xdf86).get_disasm() == "c_swsp $ra, 0xfc($sp)");
     CHECK( RISCVInstr<uint64>    (0x6082).get_disasm() == "c_ldsp $ra, 0x0($sp)");
@@ -65,6 +64,14 @@ TEST_CASE("RISCV disassembly")
     CHECK( RISCVInstr<uint64>    (0x9e99).get_disasm() == "c_subw $a3, $a4");
     CHECK( RISCVInstr<uint32>    (0x9002).get_disasm() == "c_ebreak");
     CHECK( RISCVInstr<uint32>    (0x0001).get_disasm() == "c_nop");
+}
+
+TEST_CASE("RISCV srai disassembly")
+{
+    CHECK( RISCVInstr<uint32>( 0x4028d713).get_disasm()  == "srai $a4, $a7, 2");
+    CHECK( RISCVInstr<uint64>( 0x4028d713).get_disasm()  == "srai $a4, $a7, 2");
+    CHECK( RISCVInstr<uint64>( 0x4070df1b).get_disasm()  == "sraiw $t5, $ra, 7");
+    CHECK( RISCVInstr<uint128>( 0x4070df5b).get_disasm() == "sraid $t5, $ra, 7");
 }
 
 TEST_CASE("RISCV invalid instruction")


### PR DESCRIPTION
For SLLI, SRLI, SRAI and their reduced sets from RV64 and RV128, only the bits required to perform a shift should remain as immediate value, while upper bits have to be trimmed.

Fixes #1273.