### PR TITLE
ror implementation

### DIFF
--- a/simulator/func_sim/alu.h
+++ b/simulator/func_sim/alu.h
@@ -186,6 +186,7 @@ struct ALU
 
     // Circular shifts
     template<typename I> static void rol( I* instr) { instr->v_dst[0] = circ_ls( sign_extension<bitwidth<typename I::RegisterUInt>>( instr->v_src[0]), shamt_v_src2<typename I::RegisterUInt>( instr)); }
+    template<typename I> static void ror( I* instr) { instr->v_dst[0] = circ_rs( sign_extension<bitwidth<typename I::RegisterUInt>>( instr->v_src[0]), shamt_v_src2<typename I::RegisterUInt>( instr)); }
 
     // MIPS extra shifts
     template<typename I> static void dsll32( I* instr) { instr->v_dst[0] = instr->v_src[0] << shamt_imm_32( instr); }

--- a/simulator/infra/macro.h
+++ b/simulator/infra/macro.h
@@ -247,13 +247,22 @@ static constexpr T arithmetic_rs( const T& value, size_t shamt)
     return result;
 }
 
-/*Circular left shift*/
+/* Circular left shift*/
 template<typename T>
 static constexpr T circ_ls( const T& value, size_t shamt)
 {
     if ( shamt == 0 || shamt == bitwidth<T>)
         return value;
     return ( value << shamt) | ( value >> ( bitwidth<T> - shamt));
+}
+
+/* Circular right shift */
+template<typename T>
+static constexpr T circ_rs( const T& value, size_t shamt)
+{
+    if ( shamt == 0 || shamt == bitwidth<T>)
+        return value;
+    return ( value >> shamt) | ( value << ( bitwidth<T> - shamt));
 }
 
 template<typename T>

--- a/simulator/infra/macro.h
+++ b/simulator/infra/macro.h
@@ -260,9 +260,7 @@ static constexpr T circ_ls( const T& value, size_t shamt)
 template<typename T>
 static constexpr T circ_rs( const T& value, size_t shamt)
 {
-    if ( shamt == 0 || shamt == bitwidth<T>)
-        return value;
-    return ( value >> shamt) | ( value << ( bitwidth<T> - shamt));
+    return circ_ls(value, bitwidth<T> - shamt);
 }
 
 template<typename T>

--- a/simulator/infra/t/unit_test.cpp
+++ b/simulator/infra/t/unit_test.cpp
@@ -293,6 +293,21 @@ TEST_CASE("Test uint64 circular left shift")
     CHECK( 0x0B0C'0D0A'0B0C'0D0A == circ_ls( value, 4));
 }
 
+TEST_CASE("Test uint32 circular right shift")
+{
+    uint32 value = 0xA0B0'C0D0;
+    CHECK( value == circ_rs( value, 0));
+    CHECK( value == circ_rs( value, 32));
+    CHECK( 0x0A0B'0C0D == circ_rs( value, 4));
+}
+
+TEST_CASE("Test uint64 circular right shift")
+{
+    uint64 value = 0xA0B0'C0D0'A0B0'C0D0;
+    CHECK( value == circ_rs( value, 0));
+    CHECK( value == circ_rs( value, 64));
+    CHECK( 0x0A0B'0C0D'0A0B'0C0D == circ_rs( value, 4));
+}
 TEST_CASE("Invalid target print")
 {
     std::ostringstream oss;

--- a/simulator/risc_v/riscv_instr.cpp
+++ b/simulator/risc_v/riscv_instr.cpp
@@ -93,6 +93,7 @@ template<typename I> const auto execute_orn = ALU::orn<I>;
 template<typename I> const auto execute_pack = ALU::pack<I, typename I::RegisterUInt>;
 template<typename I> const auto execute_pcnt = ALU::pcnt<I, typename I::RegisterUInt>;
 template<typename I> const auto execute_rol = ALU::rol<I>;
+template<typename I> const auto execute_ror = ALU::ror<I>;
 template<typename I> const auto execute_sbext = ALU::sbext<I>;
 template<typename I> const auto execute_slo = ALU::slo<I>;
 template<typename I> const auto execute_sro = ALU::sro<I>;
@@ -320,6 +321,7 @@ static const std::vector<RISCVTableEntry<I>> cmd_desc =
     {'B', instr_clz,        execute_clz<I>,    OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::ZERO }, { Dst::RD }, 0, 32 | 64      },
     {'B', instr_ctz,        execute_ctz<I>,    OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::ZERO }, { Dst::RD }, 0, 32 | 64      },
     {'B', instr_rol,        execute_rol<I>,    OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64      },
+    {'B', instr_ror,        execute_ror<I>,    OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64      },
     {'B', instr_clmul,      execute_clmul<I>,  OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64      },
     {'B', instr_gorc,       execute_gorc<I>,   OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64      },
     {'B', instr_unshfl,     execute_unshfl<I>, OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977

--- a/simulator/risc_v/t/unit_test.cpp
+++ b/simulator/risc_v/t/unit_test.cpp
@@ -496,6 +496,36 @@ TEST_CASE("RISCV RV64 rol")
     }
 }
 
+TEST_CASE("RISCV RV32 ror")
+{
+    CHECK( RISCVInstr<uint32>( 0x60E7D7B3).get_disasm() == "ror $a5, $a5, $a4");
+    std::vector<TestData<uint32>> cases {
+        TestData<uint32>( 0x01234567, 0,  0x01234567),
+        TestData<uint32>( 0x01234567, 4,  0x70123456),
+        TestData<uint32>( 0x01234567, 8,  0x67012345),
+        TestData<uint32>( 0x01234567, 32, 0x01234567),
+    };
+    for (std::size_t i = 0; i < cases.size(); i++) {
+        INFO( "Iteration: " << i);
+        cases[i].make_test("ror");
+    }
+}
+
+TEST_CASE("RISCV RV64 ror")
+{
+    CHECK( RISCVInstr<uint32>( 0x60E7D7B3).get_disasm() == "ror $a5, $a5, $a4");
+    std::vector<TestData<uint64>> cases {
+        TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0x0123'4567'89ab'cdef),
+        TestData<uint64>( 0x0123'4567'89ab'cdef, 4,  0xf012'3456'789a'bcde),
+        TestData<uint64>( 0x0123'4567'89ab'cdef, 8,  0xef01'2345'6789'abcd),
+        TestData<uint64>( 0x0123'4567'89ab'cdef, 64, 0x0123'4567'89ab'cdef),
+    };
+    for (std::size_t i = 0; i < cases.size(); i++) {
+        INFO( "Iteration: " << i);
+        cases[i].make_test("ror");
+    }
+}
+
 TEST_CASE("RISCV RV32 clmul")
 {
     std::vector<TestData<uint32>> cases {


### PR DESCRIPTION
Implementation of ror instruction for RV32B and RV64B
Ror instruction is similar to shift-logical operations from the base spec, except it shifts in the values from the opposite side of the register, in order. This is also called ‘circular shift’