### PR TITLE
added rori instruction

### DIFF
--- a/simulator/func_sim/alu.h
+++ b/simulator/func_sim/alu.h
@@ -186,6 +186,7 @@ struct ALU
     // Circular shifts
     template<typename I> static void rol( I* instr) { instr->v_dst[0] = circ_ls( sign_extension<bitwidth<typename I::RegisterUInt>>( instr->v_src[0]), shamt_v_src2<typename I::RegisterUInt>( instr)); }
     template<typename I> static void ror( I* instr) { instr->v_dst[0] = circ_rs( sign_extension<bitwidth<typename I::RegisterUInt>>( instr->v_src[0]), shamt_v_src2<typename I::RegisterUInt>( instr)); }
+    template<typename I> static void rori( I* instr) { instr->v_dst[0] = circ_rs( sign_extension<bitwidth<typename I::RegisterUInt>>( instr->v_src[0]), shamt_imm( instr)); }
 
     // MIPS extra shifts
     template<typename I> static void dsll32( I* instr) { instr->v_dst[0] = instr->v_src[0] << shamt_imm_32( instr); }

--- a/simulator/risc_v/riscv_instr.cpp
+++ b/simulator/risc_v/riscv_instr.cpp
@@ -102,6 +102,7 @@ template<typename I> const auto execute_slo = ALU::slo<I>;
 template<typename I> const auto execute_sro = ALU::sro<I>;
 template<typename I> const auto execute_unshfl = ALU::riscv_unshfl<I>;
 template<typename I> const auto execute_xnor = ALU::xnor<I>;
+template<typename I> const auto execute_rori = ALU::rori<I>;
 
 using Src = Reg;
 using Dst = Reg;
@@ -331,6 +332,7 @@ static const std::vector<RISCVTableEntry<I>> cmd_desc =
     {'B', instr_gorc,       execute_gorc<I>,   OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64      },
     {'B', instr_gorci,      execute_gorci<I>,  OUT_ARITHM, '7', Imm::ARITH, { Src::RS1, Src::ZERO }, { Dst::RD }, 0, 32 | 64   },
     {'B', instr_unshfl,     execute_unshfl<I>, OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64 | 128}, // NOLINT(hicpp-signed-bitwise) https://bugs.llvm.org/show_bug.cgi?id=44977
+    {'B', instr_rori,       execute_rori<I>,   OUT_ARITHM, '7', Imm::ARITH, { Src::RS1, Src::ZERO },  { Dst::RD }, 0, 32 | 64      },
 };
 
 template<typename I>

--- a/simulator/risc_v/riscv_instr.cpp
+++ b/simulator/risc_v/riscv_instr.cpp
@@ -97,12 +97,12 @@ template<typename I> const auto execute_pack = ALU::pack<I, typename I::Register
 template<typename I> const auto execute_pcnt = ALU::pcnt<I, typename I::RegisterUInt>;
 template<typename I> const auto execute_rol = ALU::rol<I>;
 template<typename I> const auto execute_ror = ALU::ror<I>;
+template<typename I> const auto execute_rori = ALU::rori<I>;
 template<typename I> const auto execute_sbext = ALU::sbext<I>;
 template<typename I> const auto execute_slo = ALU::slo<I>;
 template<typename I> const auto execute_sro = ALU::sro<I>;
 template<typename I> const auto execute_unshfl = ALU::riscv_unshfl<I>;
 template<typename I> const auto execute_xnor = ALU::xnor<I>;
-template<typename I> const auto execute_rori = ALU::rori<I>;
 
 using Src = Reg;
 using Dst = Reg;

--- a/simulator/risc_v/t/unit_test.cpp
+++ b/simulator/risc_v/t/unit_test.cpp
@@ -547,6 +547,48 @@ TEST_CASE("RISCV RV64 ror")
     }
 }
 
+TEST_CASE("RISCV RV32 rori")
+{
+    // |  01100  |     imm     |   rs1   | 101 |    rd   |   0010011   |  RORI
+    CHECK( RISCVInstr<uint32>( 0x6007D793).get_disasm() == "rori $a5, $a5, 0"); // 01100 | 0000000 (0) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    TestData<uint32>test_0 = TestData<uint32>( 0x01234567, 0,  0x01234567); // src2 (0) is not used
+    INFO( "Iteration: " << 0);
+    test_0.make_test ("rori", 0);
+    CHECK( RISCVInstr<uint32>( 0x6047D793).get_disasm() == "rori $a5, $a5, 4"); // 01100 | 0000100 (4) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    TestData<uint32>test_4 = TestData<uint32>( 0x01234567, 0,  0x70123456); // src2 (0) is not used
+    INFO( "Iteration: " << 1);
+    test_4.make_test ("rori", 4);
+    CHECK( RISCVInstr<uint32>( 0x6087D793).get_disasm() == "rori $a5, $a5, 8"); // 01100 | 0001000 (8) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    TestData<uint32>test_8 = TestData<uint32>( 0x01234567, 0,  0x67012345); // src2 (0) is not used
+    INFO( "Iteration: " << 2);
+    test_8.make_test ("rori", 8);
+    CHECK( RISCVInstr<uint32>( 0x61F7D793).get_disasm() == "rori $a5, $a5, 31"); // 01100 | 0100000 (32) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    TestData<uint32>test_31 = TestData<uint32>( 0x01234567, 0,  0x02468ace); // src2 (0) is not used
+    INFO( "Iteration: " << 3);
+    test_31.make_test ("rori", 31);
+}
+
+TEST_CASE("RISCV RV64 rori")
+{
+    // |  01100  |  imm(shamt)  |   rs1   | 101 |    rd   |   0010011   |  RORI
+    CHECK( RISCVInstr<uint64>( 0x6007D793).get_disasm() == "rori $a5, $a5, 0"); // 01100 | 0000000 (0) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    TestData<uint64>test_0 = TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0x0123'4567'89ab'cdef); // src2 (0) is not used
+    INFO( "Iteration: " << 0);
+    test_0.make_test ("rori", 0);
+    CHECK( RISCVInstr<uint64>( 0x6047D793).get_disasm() == "rori $a5, $a5, 4"); // 01100 | 0000100 (4) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    TestData<uint64>test_4 = TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0xf012'3456'789a'bcde); // src2 (0) is not used
+    INFO( "Iteration: " << 1);
+    test_4.make_test ("rori", 4);
+    CHECK( RISCVInstr<uint64>( 0x6087D793).get_disasm() == "rori $a5, $a5, 8"); // 01100 | 0001000 (8) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    TestData<uint64>test_8 = TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0xef01'2345'6789'abcd); // src2 (0) is not used
+    INFO( "Iteration: " << 2);
+    test_8.make_test ("rori", 8);
+    CHECK( RISCVInstr<uint64>( 0x63F7D793).get_disasm() == "rori $a5, $a5, 63"); // 01100 | 1000000 (64) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    TestData<uint64>test_63 = TestData<uint64>( 0x0123'4567'89ab'cdef, 0, 0x0246'8acf'1357'9bde); // src2 (0) is not used
+    INFO( "Iteration: " << 3);
+    test_63.make_test ("rori", 63);
+}
+
 TEST_CASE("RISCV RV32 clmul")
 {
     std::vector<TestData<uint32>> cases {

--- a/simulator/risc_v/t/unit_test.cpp
+++ b/simulator/risc_v/t/unit_test.cpp
@@ -547,46 +547,44 @@ TEST_CASE("RISCV RV64 ror")
     }
 }
 
+TEST_CASE("RISCV RV32 rori disassembly")
+{
+    CHECK( RISCVInstr<uint32>( 0x6007D793).get_disasm() == "rori $a5, $a5, 0");  // 01100 | 0000000 (0)  | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    CHECK( RISCVInstr<uint32>( 0x60F7D793).get_disasm() == "rori $a5, $a5, 15"); // 01100 | 0001111 (15) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+    CHECK( RISCVInstr<uint32>( 0x61F7D793).get_disasm() == "rori $a5, $a5, 31"); // 01100 | 0011111 (31) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+}
+
+TEST_CASE("RISCV RV64 rori disassembly")
+{
+    CHECK( RISCVInstr<uint64>( 0x63F7D793).get_disasm() == "rori $a5, $a5, 63"); // 01100 | 0111111 (63) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
+}
+
 TEST_CASE("RISCV RV32 rori")
 {
-    // |  01100  |     imm     |   rs1   | 101 |    rd   |   0010011   |  RORI
-    CHECK( RISCVInstr<uint32>( 0x6007D793).get_disasm() == "rori $a5, $a5, 0"); // 01100 | 0000000 (0) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
-    TestData<uint32>test_0 = TestData<uint32>( 0x01234567, 0,  0x01234567); // src2 (0) is not used
-    INFO( "Iteration: " << 0);
-    test_0.make_test ("rori", 0);
-    CHECK( RISCVInstr<uint32>( 0x6047D793).get_disasm() == "rori $a5, $a5, 4"); // 01100 | 0000100 (4) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
-    TestData<uint32>test_4 = TestData<uint32>( 0x01234567, 0,  0x70123456); // src2 (0) is not used
-    INFO( "Iteration: " << 1);
-    test_4.make_test ("rori", 4);
-    CHECK( RISCVInstr<uint32>( 0x6087D793).get_disasm() == "rori $a5, $a5, 8"); // 01100 | 0001000 (8) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
-    TestData<uint32>test_8 = TestData<uint32>( 0x01234567, 0,  0x67012345); // src2 (0) is not used
-    INFO( "Iteration: " << 2);
-    test_8.make_test ("rori", 8);
-    CHECK( RISCVInstr<uint32>( 0x61F7D793).get_disasm() == "rori $a5, $a5, 31"); // 01100 | 0100000 (32) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
-    TestData<uint32>test_31 = TestData<uint32>( 0x01234567, 0,  0x02468ace); // src2 (0) is not used
-    INFO( "Iteration: " << 3);
-    test_31.make_test ("rori", 31);
+    std::vector<TestData<uint32>> cases {
+        TestData<uint32>( 0x01234567, 0,  0x01234567),
+        TestData<uint32>( 0x01234567, 4,  0x70123456),
+        TestData<uint32>( 0x01234567, 8,  0x67012345),
+        TestData<uint32>( 0x01234567, 31, 0x02468ace),
+    };
+    for (std::size_t i = 0; i < cases.size(); i++) {
+        INFO( "Iteration: " << i);
+        cases[i].make_test("ror");
+    }
 }
 
 TEST_CASE("RISCV RV64 rori")
 {
-    // |  01100  |  imm(shamt)  |   rs1   | 101 |    rd   |   0010011   |  RORI
-    CHECK( RISCVInstr<uint64>( 0x6007D793).get_disasm() == "rori $a5, $a5, 0"); // 01100 | 0000000 (0) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
-    TestData<uint64>test_0 = TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0x0123'4567'89ab'cdef); // src2 (0) is not used
-    INFO( "Iteration: " << 0);
-    test_0.make_test ("rori", 0);
-    CHECK( RISCVInstr<uint64>( 0x6047D793).get_disasm() == "rori $a5, $a5, 4"); // 01100 | 0000100 (4) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
-    TestData<uint64>test_4 = TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0xf012'3456'789a'bcde); // src2 (0) is not used
-    INFO( "Iteration: " << 1);
-    test_4.make_test ("rori", 4);
-    CHECK( RISCVInstr<uint64>( 0x6087D793).get_disasm() == "rori $a5, $a5, 8"); // 01100 | 0001000 (8) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
-    TestData<uint64>test_8 = TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0xef01'2345'6789'abcd); // src2 (0) is not used
-    INFO( "Iteration: " << 2);
-    test_8.make_test ("rori", 8);
-    CHECK( RISCVInstr<uint64>( 0x63F7D793).get_disasm() == "rori $a5, $a5, 63"); // 01100 | 1000000 (64) | 01111 ($a5) | 101 | 01111 ($a5) | 0010011
-    TestData<uint64>test_63 = TestData<uint64>( 0x0123'4567'89ab'cdef, 0, 0x0246'8acf'1357'9bde); // src2 (0) is not used
-    INFO( "Iteration: " << 3);
-    test_63.make_test ("rori", 63);
+    std::vector<TestData<uint64>> cases {
+        TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0x0123'4567'89ab'cdef),
+        TestData<uint64>( 0x0123'4567'89ab'cdef, 4,  0xf012'3456'789a'bcde),
+        TestData<uint64>( 0x0123'4567'89ab'cdef, 8,  0xef01'2345'6789'abcd),
+        TestData<uint64>( 0x0123'4567'89ab'cdef, 63, 0x0246'8acf'1357'9bde),
+    };
+    for (std::size_t i = 0; i < cases.size(); i++) {
+        INFO( "Iteration: " << i);
+        cases[i].make_test("ror");
+    }
 }
 
 TEST_CASE("RISCV RV32 clmul")

--- a/simulator/risc_v/t/unit_test.cpp
+++ b/simulator/risc_v/t/unit_test.cpp
@@ -561,29 +561,33 @@ TEST_CASE("RISCV RV64 rori disassembly")
 
 TEST_CASE("RISCV RV32 rori")
 {
-    std::vector<TestData<uint32>> cases {
-        TestData<uint32>( 0x01234567, 0,  0x01234567),
-        TestData<uint32>( 0x01234567, 4,  0x70123456),
-        TestData<uint32>( 0x01234567, 8,  0x67012345),
-        TestData<uint32>( 0x01234567, 31, 0x02468ace),
+    //src2 is zero as it is not used by rori and other immediate instructions
+    std::vector<std::pair<TestData<uint32>, int>> cases {
+        {TestData<uint32>( 0x01234567, 0, 0x01234567),  0},
+        {TestData<uint32>( 0x01234567, 0, 0x70123456),  4},
+        {TestData<uint32>( 0x01234567, 0, 0x67012345),  8},
+        {TestData<uint32>( 0x01234567, 0, 0x02468ace), 31},
+        {TestData<uint32>( 0x01234567, 0, 0x01234567), 32},
     };
     for (std::size_t i = 0; i < cases.size(); i++) {
         INFO( "Iteration: " << i);
-        cases[i].make_test("ror");
+        cases[i].first.make_test("rori", cases[i].second);
     }
 }
 
 TEST_CASE("RISCV RV64 rori")
 {
-    std::vector<TestData<uint64>> cases {
-        TestData<uint64>( 0x0123'4567'89ab'cdef, 0,  0x0123'4567'89ab'cdef),
-        TestData<uint64>( 0x0123'4567'89ab'cdef, 4,  0xf012'3456'789a'bcde),
-        TestData<uint64>( 0x0123'4567'89ab'cdef, 8,  0xef01'2345'6789'abcd),
-        TestData<uint64>( 0x0123'4567'89ab'cdef, 63, 0x0246'8acf'1357'9bde),
+    //src2 is zero as it is not used by rori and other immediate instructions
+    std::vector<std::pair<TestData<uint64>, int>> cases {
+        {TestData<uint64>( 0x0123'4567'89ab'cdef, 0, 0x0123'4567'89ab'cdef),  0},
+        {TestData<uint64>( 0x0123'4567'89ab'cdef, 0, 0xf012'3456'789a'bcde),  4},
+        {TestData<uint64>( 0x0123'4567'89ab'cdef, 0, 0xef01'2345'6789'abcd),  8},
+        {TestData<uint64>( 0x0123'4567'89ab'cdef, 0, 0x0246'8acf'1357'9bde), 63},
+        {TestData<uint64>( 0x0123'4567'89ab'cdef, 0, 0x0123'4567'89ab'cdef), 64},
     };
     for (std::size_t i = 0; i < cases.size(); i++) {
         INFO( "Iteration: " << i);
-        cases[i].make_test("ror");
+        cases[i].first.make_test("rori", cases[i].second);
     }
 }
 


### PR DESCRIPTION
Added RORI instruction: it is similar to shift-logical operations, except it shift in the values from the right side of the register to the left side, in order.  This is also called ‘circular right shift’. It is rv32b instruction that can operate on RV32 and RV64 cpus. Syntax is: "rori rd, rs1, imm". Imm is the value between 0 and [REGISTER_LENGTH - 1]. Bitmap of the instruction is:
    3                            2                            1                            0
 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
 | 01100  |       imm      |     rs1    | 101  |    rd      |  00100  | 11 |  RORI