### PR TITLE
Add add.uw instruction

### DIFF
--- a/simulator/func_sim/alu.h
+++ b/simulator/func_sim/alu.h
@@ -262,6 +262,8 @@ struct ALU
                 instr->v_dst[0] ^= instr->v_src[0] << index;
     }
 
+    template<typename T> static void add_uw( Instr* instr) { instr->v_dst[0] = instr->v_src[1] + ( bitmask<T>(32) & instr->v_src[0]); }
+
     // Bit manipulations
     template<typename T> static
     void pack( Instr* instr)

--- a/simulator/risc_v/riscv_instr.cpp
+++ b/simulator/risc_v/riscv_instr.cpp
@@ -93,6 +93,7 @@ template<typename I> const auto execute_divu = RISCVMultALU<I>::template div<typ
 template<typename I> const auto execute_rem = RISCVMultALU<I>::template rem<sign_t<typename I::RegisterUInt>>;
 template<typename I> const auto execute_remu = RISCVMultALU<I>::template rem<typename I::RegisterUInt>;
 // B
+template<typename I> const auto execute_add_uw = RISCVALU<I>::template add_uw<typename I::RegisterUInt>;
 template<typename I> const auto execute_bext = RISCVALU<I>::template sbext<typename I::RegisterUInt>;
 template<typename I> const auto execute_bfp = RISCVALU<I>::bit_field_place;
 template<typename I> const auto execute_binv = RISCVALU<I>::template sbinv<typename I::RegisterUInt>;
@@ -360,6 +361,7 @@ static const std::vector<RISCVTableEntry<I>> cmd_desc =
     {'B', instr_shfl,       execute_shfl<I>,   OUT_ARITHM, ' ', Imm::NO, { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64      },
     {'B', instr_sloi,       execute_sloi<I>,   OUT_ARITHM, '7', Imm::ARITH, { Src::RS1, Src::ZERO }, { Dst::RD }, 0, 32 | 64   },
     {'B', instr_sroi,       execute_sroi<I>,   OUT_ARITHM, '7', Imm::ARITH, { Src::RS1, Src::ZERO }, { Dst::RD }, 0, 32 | 64   },
+    {'B', instr_add_uw,     execute_add_uw<I>, OUT_ARITHM, ' ', Imm::NO,    { Src::RS1, Src::RS2 },  { Dst::RD }, 0,      64   },
 };
 
 

--- a/simulator/risc_v/t/unit_test.cpp
+++ b/simulator/risc_v/t/unit_test.cpp
@@ -117,6 +117,7 @@ TEST_CASE("RISCV disassembly")
     TEST_RV32_DISASM  ( 0xAE6C633,  "min $a2, $a3, $a4");
     TEST_RV32_DISASM  ( 0x0ae7d7b3, "minu $a5, $a5, $a4");
     TEST_RV32_DISASM  ( 0x48D747B3, "packu $a5, $a4, $a3");
+    TEST_RV64_DISASM  ( 0x8D707BB,  "add_uw $a5, $a4, $a3"); // 0000100 | 01101 ($a3) | 01110 ($a4) | 000 | 01111 ($a5) | 0111011
 
     SECTION ("RISCV invalid instruction") {
         TEST_RV32_DISASM ( 0x0, "unknown" );
@@ -352,6 +353,10 @@ TEST_RV32_RR_OP( 3, minu, 0x22222222, 0xbbbbbbbb, 0x22222222)
 
 TEST_RV32_RR_OP( 1, packu, 0x1111ffff, 0xffff2222, 0x11113333)
 TEST_RV64_RR_OP( 1, packu, 0x11111111ffffffff, 0xffffffff22222222, 0x1111111133333333)
+
+TEST_RV64_RR_OP( 1, add_uw, 0x12344321b5a69788, 0xabababab82736455, 0x1234432133333333)
+TEST_RV64_RR_OP( 2, add_uw, 0x1111111233333332, 0x11111111ffffffff, 0x1111111133333333) // 32 bits overflow
+TEST_RV64_RR_OP( 3, add_uw, 0x01010102222221ce, 0xffffffffffffffac, 0x0101010122222222) // 64 bits overflow
 
 
 TEST_CASE("RISCV bytes dump")


### PR DESCRIPTION
Add unsigned word instruction (RISC-V Bit-Manipulation ISA-extensions).
Opcode : 1101110.

This instruction performs an XLEN-wide addition between rs2
and the zero-extended least-significant word of rs1:

let base = X(rs2);
let index = EXTZ(X(rs1)[31..0]);
X(rd) = base + index;