### PR TITLE
Add bset instruction.

### DIFF
--- a/simulator/func_sim/alu.h
+++ b/simulator/func_sim/alu.h
@@ -285,6 +285,8 @@ struct ALU
         instr->v_dst[0] = ( (instr->v_src[0] >> pack_width) | (instr->v_src[1] & (bitmask<T>(pack_width) << pack_width)));
     }
 
+    static void bset( Instr* instr) { instr->v_dst[0] = instr->v_src[0] | (lsb_set<RegisterUInt>() << shamt_v_src2<RegisterUInt>(instr)); }
+
     // Branches
     template<Predicate p> static
     void branch( Instr* instr)

--- a/simulator/risc_v/riscv_instr.cpp
+++ b/simulator/risc_v/riscv_instr.cpp
@@ -96,6 +96,7 @@ template<typename I> const auto execute_remu = RISCVMultALU<I>::template rem<typ
 template<typename I> const auto execute_bseti = RISCVALU<I>::template bseti<typename I::RegisterUInt>;
 template<typename I> const auto execute_add_uw = RISCVALU<I>::template add_uw<typename I::RegisterUInt>;
 template<typename I> const auto execute_bclr = RISCVALU<I>::template bclr<typename I::RegisterUInt>;
+template<typename I> const auto execute_bset = RISCVALU<I>::bset;
 template<typename I> const auto execute_bext = RISCVALU<I>::template sbext<typename I::RegisterUInt>;
 template<typename I> const auto execute_bfp = RISCVALU<I>::bit_field_place;
 template<typename I> const auto execute_binv = RISCVALU<I>::template sbinv<typename I::RegisterUInt>;
@@ -365,7 +366,8 @@ static const std::vector<RISCVTableEntry<I>> cmd_desc =
     {'B', instr_sroi,       execute_sroi<I>,   OUT_ARITHM, '7', Imm::ARITH, { Src::RS1, Src::ZERO }, { Dst::RD }, 0, 32 | 64   },
     {'B', instr_add_uw,     execute_add_uw<I>, OUT_ARITHM, ' ', Imm::NO,    { Src::RS1, Src::RS2 },  { Dst::RD }, 0,      64   },
     {'B', instr_bclr,       execute_bclr<I>,   OUT_ARITHM, ' ', Imm::NO,    { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64   },
-    {'B', instr_bseti,      execute_bseti<I>,  OUT_ARITHM, '7', Imm::ARITH, { Src::RS1, Src::ZERO},  { Dst::RD},  0, 32 | 64   }
+    {'B', instr_bseti,      execute_bseti<I>,  OUT_ARITHM, '7', Imm::ARITH, { Src::RS1, Src::ZERO},  { Dst::RD},  0, 32 | 64   },
+    {'B', instr_bset,       execute_bset<I>,   OUT_ARITHM, ' ', Imm::NO,    { Src::RS1, Src::RS2 },  { Dst::RD }, 0, 32 | 64   }
 };
 
 

--- a/simulator/risc_v/t/unit_test.cpp
+++ b/simulator/risc_v/t/unit_test.cpp
@@ -125,6 +125,9 @@ TEST_CASE("RISCV disassembly")
                                                           // isssue is #1508 
     TEST_RV64_DISASM  ( 0x48D717B3,  "bclr $a5, $a4, $a3"); // 0100100 | 01101 ($a3) | 01110 ($a4) | 001 | 01111 ($a5) | 0110011
 
+    TEST_RV32_DISASM  ( 0x28F716B3,  "bset $a3, $a4, $a5");
+    TEST_RV64_DISASM  ( 0x28D717B3,  "bset $a5, $a4, $a3");
+
     SECTION ("RISCV invalid instruction") {
         TEST_RV32_DISASM ( 0x0, "unknown" );
         TEST_RV32_DISASM ( 0xf6000053, "unknown" );
@@ -413,6 +416,18 @@ TEST_RV64_RR_OP(  7, bclr, 0xffbfffffffffffff, 0xffffffffffffffff, 0x00000000000
 TEST_RV64_RR_OP(  8, bclr, 0x0000000000000000, 0x0040000000000000, 0x0000000000000076) // overflow test
 TEST_RV64_RR_OP(  9, bclr, 0x7fffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff) // overflow test
 TEST_RV64_RR_OP( 10, bclr, 0x0000000000000000, 0x8000000000000000, 0xffffffffffffffff) // overflow test
+
+TEST_RV32_RR_OP( 1, bset, 0x00000010, 0x00000000, 0x4)
+TEST_RV32_RR_OP( 2, bset, 0xFFFFFFF1, 0xFFFFFFF0, 0x0)
+TEST_RV32_RR_OP( 3, bset, 0xFFFFFFF3, 0xFFFFFFF1, 0x1)
+TEST_RV32_RR_OP( 4, bset, 0x00000002, 0x00000000, 0xFFFFFF01) // overflow test
+TEST_RV32_RR_OP( 5, bset, 0x00010000, 0x00000000, 0xFFFFFFF0) // overflow test
+
+TEST_RV64_RR_OP( 1, bset, 0x0000000000000100, 0x0000000000000000, 0x8)
+TEST_RV64_RR_OP( 2, bset, 0x0000000000008000, 0x0000000000000000, 0xF)
+TEST_RV64_RR_OP( 3, bset, 0xFFFFFFFFFFFFFFF4, 0xFFFFFFFFFFFFFFF0, 0x2)
+TEST_RV64_RR_OP( 4, bset, 0xAAAAAAAAAAAAAAA2, 0xAAAAAAAAAAAAAAA0, 0xFFFFFFFFFFFFFF01) // overflow test
+TEST_RV64_RR_OP( 5, bset, 0x1111111111111100, 0x1111111111111000, 0xFFFFFFFFFFFFFF08) // overflow test
 
 TEST_CASE("RISCV bytes dump")
 {


### PR DESCRIPTION
Single-Bit Set (Register) instruction

Mnemonic: bset rd, rs1, rs2

Opcode : 1100110.

This instruction returns rs1 with a single bit set at the index specified in rs2.
The index is read from the lower log2(XLEN) bits of rs2.

Operation:

```
let index = X(rs2) & (XLEN - 1);
X(rd) = X(rs1) | (1 << index);
```